### PR TITLE
ci: add GitHub Actions workflow for staging deploy on pull request

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,0 +1,85 @@
+name: Staging Deploy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: staging-deploy
+  cancel-in-progress: true
+
+jobs:
+  build-push-api:
+    name: API – build & push staging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to registry
+        uses: docker/login-action@v3
+        with:
+          registry: dockregistry.xju.fr
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build and push API
+        uses: docker/build-push-action@v6
+        with:
+          context: ./back
+          push: true
+          platforms: linux/amd64
+          tags: |
+            dockregistry.xju.fr/mccbng/api:staging
+            dockregistry.xju.fr/mccbng/api:staging-pr-${{ github.event.pull_request.number }}
+          cache-from: type=registry,ref=dockregistry.xju.fr/mccbng/api:staging
+          cache-to: type=inline
+
+  build-push-front:
+    name: Front – build & push staging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+          cache-dependency-path: front/yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: front
+
+      - name: Build staging assets
+        run: yarn build:staging
+        working-directory: front
+        env:
+          VITE_API_URL: ${{ secrets.VITE_API_URL_STAGING }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to registry
+        uses: docker/login-action@v3
+        with:
+          registry: dockregistry.xju.fr
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build and push Front
+        uses: docker/build-push-action@v6
+        with:
+          context: ./front
+          push: true
+          platforms: linux/amd64
+          tags: |
+            dockregistry.xju.fr/mccbng/front:staging
+            dockregistry.xju.fr/mccbng/front:staging-pr-${{ github.event.pull_request.number }}
+          cache-from: type=registry,ref=dockregistry.xju.fr/mccbng/front:staging
+          cache-to: type=inline

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -19,13 +19,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to registry
-        uses: docker/login-action@v3
-        with:
-          registry: dockregistry.xju.fr
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
       - name: Build and push API
         uses: docker/build-push-action@v6
         with:
@@ -45,41 +38,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-          cache: yarn
-          cache-dependency-path: front/yarn.lock
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-        working-directory: front
-
-      - name: Build staging assets
-        run: yarn build:staging
-        working-directory: front
-        env:
-          VITE_API_URL: ${{ secrets.VITE_API_URL_STAGING }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Log in to registry
-        uses: docker/login-action@v3
-        with:
-          registry: dockregistry.xju.fr
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Build and push Front
         uses: docker/build-push-action@v6
         with:
-          context: ./front
+          context: .
+          file: ./front/Dockerfile
           push: true
           platforms: linux/amd64
           tags: |
             dockregistry.xju.fr/mccbng/front:staging
             dockregistry.xju.fr/mccbng/front:staging-pr-${{ github.event.pull_request.number }}
+          build-args: |
+            VITE_API_URL=${{ secrets.VITE_API_URL_STAGING }}
           cache-from: type=registry,ref=dockregistry.xju.fr/mccbng/front:staging
           cache-to: type=inline

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,5 +1,27 @@
+# ---- Build ----
+FROM node:22-slim AS builder
+
+WORKDIR /app
+
+# Copy workspace manifests first for better layer caching
+COPY package.json yarn.lock ./
+COPY back/package.json ./back/
+COPY front/package.json ./front/
+COPY vue-touch-events/ ./vue-touch-events/
+
+RUN yarn install --frozen-lockfile
+
+# Copy front source after deps are installed
+COPY front/ ./front/
+
+ARG VITE_API_URL
+ENV VITE_API_URL=${VITE_API_URL}
+
+WORKDIR /app/front
+RUN yarn build:staging
+
 # ---- Prod ----
 FROM nginx
 
-COPY nginx.conf /etc/nginx/conf.d/default.conf
-COPY dist/ /usr/share/nginx/html
+COPY --from=builder /app/front/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/front/dist /usr/share/nginx/html

--- a/front/package.json
+++ b/front/package.json
@@ -17,9 +17,9 @@
     "type-check:watch": "vue-tsc --noEmit --watch",
     "lint": "eslint src --ext .vue,.js,.jsx,.ts,.tsx --fix",
     "lint:check": "eslint src --ext .vue,.js,.jsx,.ts,.tsx",
-    "docker:staging:build": "docker buildx build --platform linux/amd64 -t dockregistry.xju.fr/mccbng/front:staging .",
+    "docker:staging:build": "docker buildx build --platform linux/amd64 -t dockregistry.xju.fr/mccbng/front:staging -f Dockerfile ..",
     "docker:staging:push": "docker push dockregistry.xju.fr/mccbng/front:staging",
-    "docker:latest:build": "docker buildx build --platform linux/amd64 -t dockregistry.xju.fr/mccbng/front:latest .",
+    "docker:latest:build": "docker buildx build --platform linux/amd64 -t dockregistry.xju.fr/mccbng/front:latest -f Dockerfile ..",
     "docker:latest:push": "docker push dockregistry.xju.fr/mccbng/front:latest",
     "docker:run": "docker run -p 3000:3000 -d front"
   },


### PR DESCRIPTION
Builds and pushes Docker images for the API (dockregistry.xju.fr/mccbng/api)
and the front (dockregistry.xju.fr/mccbng/front) to the staging tag whenever
a pull request is opened or updated.

Required GitHub secrets:
  - REGISTRY_USERNAME / REGISTRY_PASSWORD  →  dockregistry.xju.fr credentials
  - VITE_API_URL_STAGING                   →  backend URL for the front build

https://claude.ai/code/session_01BC1tPePfu15SpqnuSWGGu8