### PR TITLE
feat(front): build frontend inside Docker like the backend

### DIFF
--- a/front/.dockerignore
+++ b/front/.dockerignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+dist

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,5 +1,20 @@
+# ---- Build ----
+FROM node:22-slim AS build
+
+WORKDIR /app
+
+# Install app dependencies
+COPY package*.json ./
+
+RUN yarn
+
+# Bundle app source code
+COPY . .
+
+RUN yarn build
+
 # ---- Prod ----
 FROM nginx
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
-COPY dist/ /usr/share/nginx/html
+COPY --from=build /app/dist /usr/share/nginx/html


### PR DESCRIPTION
Replace the pre-built dist copy approach with a multi-stage Docker build.
The first stage installs dependencies and runs yarn build inside the container,
then the second stage copies the built output to nginx — consistent with how
the backend Dockerfile builds the TypeScript source inside Docker.

Also exclude dist/ from the Docker build context via .dockerignore since
the build now happens inside the container.

https://claude.ai/code/session_01SUmDBvYDpXJriDLtnbpMjn