### PR TITLE
feat: add docker-compose build & push pipeline

### DIFF
--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+set -e
+
+# -------------------------------------------------------
+# Build & Push script for mccbng front and back images.
+# Runs inside a Docker container with access to a Docker
+# daemon (via socket mount or DinD).
+# -------------------------------------------------------
+
+REGISTRY="${REGISTRY:-dockregistry.xju.fr/mccbng}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+GIT_REPO="${GIT_REPO:-https://github.com/XjulI1/mccbng.git}"
+GIT_BRANCH="${GIT_BRANCH:-main}"
+
+echo "============================================"
+echo " mccbng - Build & Push"
+echo "============================================"
+echo " Registry : ${REGISTRY}"
+echo " Tag      : ${IMAGE_TAG}"
+echo " Repo     : ${GIT_REPO}"
+echo " Branch   : ${GIT_BRANCH}"
+echo "============================================"
+
+# Install git (Alpine-based docker:cli image)
+apk add --no-cache git > /dev/null 2>&1
+
+# Clone the repository
+WORK_DIR=$(mktemp -d)
+echo ""
+echo "=> Cloning repository..."
+git clone --branch "${GIT_BRANCH}" --depth 1 "${GIT_REPO}" "${WORK_DIR}"
+
+# Build front image
+echo ""
+echo "=> Building front image: ${REGISTRY}/front:${IMAGE_TAG}"
+docker build -t "${REGISTRY}/front:${IMAGE_TAG}" "${WORK_DIR}/front"
+
+# Build back (api) image
+echo ""
+echo "=> Building api image: ${REGISTRY}/api:${IMAGE_TAG}"
+docker build -t "${REGISTRY}/api:${IMAGE_TAG}" "${WORK_DIR}/back"
+
+# Push images to registry
+echo ""
+echo "=> Pushing ${REGISTRY}/front:${IMAGE_TAG}"
+docker push "${REGISTRY}/front:${IMAGE_TAG}"
+
+echo ""
+echo "=> Pushing ${REGISTRY}/api:${IMAGE_TAG}"
+docker push "${REGISTRY}/api:${IMAGE_TAG}"
+
+# Cleanup
+rm -rf "${WORK_DIR}"
+
+echo ""
+echo "============================================"
+echo " Done!"
+echo "  - ${REGISTRY}/front:${IMAGE_TAG}"
+echo "  - ${REGISTRY}/api:${IMAGE_TAG}"
+echo "============================================"

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -35,6 +35,20 @@ echo ""
 echo "=> Building front image: ${REGISTRY}/front:${IMAGE_TAG}"
 docker build -t "${REGISTRY}/front:${IMAGE_TAG}" "${WORK_DIR}/front"
 
+# Create a dummy datasource config for the build (gitignored, removed during Docker build)
+cat > "${WORK_DIR}/back/src/datasources/mccb-mysql.datasource.config.json" <<'DSCFG'
+{
+  "name": "mccb_mysql",
+  "connector": "mysql",
+  "url": "",
+  "host": "",
+  "port": 3306,
+  "user": "",
+  "password": "",
+  "database": ""
+}
+DSCFG
+
 # Build back (api) image
 echo ""
 echo "=> Building api image: ${REGISTRY}/api:${IMAGE_TAG}"

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,3 +1,5 @@
+version: '3'
+
 services:
   builder:
     image: docker:cli

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -7,6 +7,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./build-and-push.sh:/build-and-push.sh:ro
     environment:
+      DOCKER_API_VERSION: ${DOCKER_API_VERSION:-1.43}
       GIT_REPO: ${GIT_REPO:-https://github.com/XjulI1/mccbng.git}
       GIT_BRANCH: ${GIT_BRANCH:-main}
       REGISTRY: ${REGISTRY:-dockregistry.xju.fr/mccbng}

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,12 @@
+services:
+  builder:
+    image: docker:cli
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./build-and-push.sh:/build-and-push.sh:ro
+    environment:
+      GIT_REPO: ${GIT_REPO:-https://github.com/XjulI1/mccbng.git}
+      GIT_BRANCH: ${GIT_BRANCH:-main}
+      REGISTRY: ${REGISTRY:-dockregistry.xju.fr/mccbng}
+      IMAGE_TAG: ${IMAGE_TAG:-latest}
+    entrypoint: ["sh", "/build-and-push.sh"]


### PR DESCRIPTION
Add a docker-compose.build.yml and build-and-push.sh script that allow
building and pushing front and api Docker images from any server with
Docker. Uses docker:cli with host socket mount to clone the repo, build
both images, and push them to the registry.

Usage: docker compose -f docker-compose.build.yml up
Configurable via env vars: GIT_REPO, GIT_BRANCH, REGISTRY, IMAGE_TAG.

https://claude.ai/code/session_01Cj2HiT7Xhy9DdeJJXm6SLS