### PR TITLE
feat(front): replace env variables with runtime config.js

### DIFF
--- a/front/index.html
+++ b/front/index.html
@@ -23,6 +23,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="app"></div>
+    <script src="/config.js"></script>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/front/public/config.js
+++ b/front/public/config.js
@@ -1,0 +1,3 @@
+window.env = {
+  VITE_API_URL: ''
+}

--- a/front/src/components/OperationForm.vue
+++ b/front/src/components/OperationForm.vue
@@ -274,7 +274,7 @@
         const suggestions = await suggestCategories(
           newName,
           store.state.user.token,
-          import.meta.env.VITE_API_URL
+          window.env.VITE_API_URL
         )
         suggestedCategoriesData.value = suggestions
 

--- a/front/src/components/Stats/TimeSeriesEvolutionSoldes.vue
+++ b/front/src/components/Stats/TimeSeriesEvolutionSoldes.vue
@@ -109,7 +109,7 @@
   fetchEvolutionSolde(
     userID.value,
     userToken.value,
-    import.meta.env.VITE_API_URL
+    window.env.VITE_API_URL
   ).then((results) => {
     let sum = results.soldeGlobal
     global.value = results.global.map((data) => {

--- a/front/src/shims-vue.d.ts
+++ b/front/src/shims-vue.d.ts
@@ -1,4 +1,10 @@
 /* eslint-disable */
+interface Window {
+  env: {
+    VITE_API_URL: string;
+  };
+}
+
 declare module "*.vue" {
   import type { DefineComponent } from "vue";
   const component: DefineComponent<{}, {}, any>;

--- a/front/src/store/category.ts
+++ b/front/src/store/category.ts
@@ -22,7 +22,7 @@ export default {
   actions: {
     fetchCategoryList ({ state, rootState, commit }) {
       if (state.list.length < 2) {
-        fetchCategoryList(rootState.user.id, rootState.user.token, import.meta.env.VITE_API_URL)
+        fetchCategoryList(rootState.user.id, rootState.user.token, window.env.VITE_API_URL)
           .then((categories) => {
             commit('setCategoryList', categories)
           })

--- a/front/src/store/compte.ts
+++ b/front/src/store/compte.ts
@@ -180,7 +180,7 @@ export default {
     },
 
     generateRecurringOperations ({ rootState }) {
-      generateRecurringOperations(rootState.user.id, rootState.user.token, import.meta.env.VITE_API_URL)
+      generateRecurringOperations(rootState.user.id, rootState.user.token, window.env.VITE_API_URL)
     },
 
     fetchActiveAccount ({ state, commit, getters, dispatch, rootState }, accountID) {
@@ -188,7 +188,7 @@ export default {
 
       dispatch('fetchOperationsOfActiveAccount')
 
-      sumForACompte(rootState.user.token, accountID, import.meta.env.VITE_API_URL)
+      sumForACompte(rootState.user.token, accountID, window.env.VITE_API_URL)
         .then(({ TotalChecked, TotalNotChecked }) => {
           commit('setNewBalances', { TotalChecked, TotalNotChecked })
         })
@@ -197,7 +197,7 @@ export default {
     fetchAccountList ({ rootState, commit }) {
       const userID = rootState.user.id
       const userToken = rootState.user.token
-      const APIURL = import.meta.env.VITE_API_URL
+      const APIURL = window.env.VITE_API_URL
 
       fetchAccountList(userID, userToken, APIURL)
         .then((accountList) => {

--- a/front/src/store/operation.ts
+++ b/front/src/store/operation.ts
@@ -75,7 +75,7 @@ export default {
       fetchOperationsForAccount(
         rootState.compte.activeAccount.IDcompte,
         rootState.user.token,
-        import.meta.env.VITE_API_URL,
+        window.env.VITE_API_URL,
         0,
         state.operationsLimit
       ).then((operations) => {
@@ -98,7 +98,7 @@ export default {
       return fetchOperationsForAccount(
         rootState.compte.activeAccount.IDcompte,
         rootState.user.token,
-        import.meta.env.VITE_API_URL,
+        window.env.VITE_API_URL,
         state.operationsSkip,
         state.operationsLimit
       ).then((operations) => {
@@ -115,7 +115,7 @@ export default {
       await updateOperation(
         operation,
         rootState.user.token,
-        import.meta.env.VITE_API_URL
+        window.env.VITE_API_URL
       )
 
       dispatch('fetchActiveAccount', operation.IDcompte)
@@ -125,7 +125,7 @@ export default {
       await deleteOperation(
         operation.IDop,
         rootState.user.token,
-        import.meta.env.VITE_API_URL
+        window.env.VITE_API_URL
       )
 
       dispatch('fetchActiveAccount', operation.IDcompte)
@@ -143,7 +143,7 @@ export default {
           IDcompte: operation.IDcompteDebit
         },
         rootState.user.token,
-        import.meta.env.VITE_API_URL
+        window.env.VITE_API_URL
       )
 
       await updateOperation(
@@ -153,7 +153,7 @@ export default {
           IDcompte: operation.IDcompteCredit
         },
         rootState.user.token,
-        import.meta.env.VITE_API_URL
+        window.env.VITE_API_URL
       )
 
       dispatch('fetchActiveAccount', operation.IDcompteDebit)
@@ -165,7 +165,7 @@ export default {
 
       fetchRecurrOperation(
         rootState.user.token,
-        import.meta.env.VITE_API_URL
+        window.env.VITE_API_URL
       ).then((operations) => {
         commit('setOperationsOfActiveAccount', operations)
         commit('setRecurringOperations', operations)
@@ -182,7 +182,7 @@ export default {
           Frequence: parseInt(operationRecurrente.Frequence)
         },
         rootState.user.token,
-        import.meta.env.VITE_API_URL
+        window.env.VITE_API_URL
       )
 
       dispatch('fetchRecurrOperation')
@@ -195,7 +195,7 @@ export default {
       await deleteRecurringOperation(
         operationRecurrente.IDopRecu,
         rootState.user.token,
-        import.meta.env.VITE_API_URL
+        window.env.VITE_API_URL
       )
 
       dispatch('fetchRecurrOperation')
@@ -211,7 +211,7 @@ export default {
         searchTerms,
         rootState.compte.accountList,
         rootState.user.token,
-        import.meta.env.VITE_API_URL,
+        window.env.VITE_API_URL,
         0,
         state.operationsLimit
       ).then((operations) => {
@@ -235,7 +235,7 @@ export default {
         state.currentSearchTerms,
         rootState.compte.accountList,
         rootState.user.token,
-        import.meta.env.VITE_API_URL,
+        window.env.VITE_API_URL,
         state.operationsSkip,
         state.operationsLimit
       ).then((operations) => {
@@ -254,7 +254,7 @@ export default {
       fetchOperations(
         where,
         rootState.user.token,
-        import.meta.env.VITE_API_URL
+        window.env.VITE_API_URL
       ).then((operations) => {
         commit('setOperationsOfActiveAccount', operations)
         commit('setHasMoreOperations', false)

--- a/front/src/store/stats.ts
+++ b/front/src/store/stats.ts
@@ -40,7 +40,7 @@ export default {
 
   actions: {
     fetchSumByUserByMonth ({ state, commit, rootState }) {
-      axios.get(import.meta.env.VITE_API_URL + '/api/operations/sumByUserByMonth', {
+      axios.get(window.env.VITE_API_URL + '/api/operations/sumByUserByMonth', {
         headers: {
           Authorization: 'Bearer ' + rootState.user.token
         },
@@ -57,7 +57,7 @@ export default {
     fetchSumCategoriesByUserByMonth ({ dispatch, commit, state, rootState }) {
       dispatch('fetchCategoryList')
 
-      axios.get(import.meta.env.VITE_API_URL + '/api/operations/sumCategoriesByUserByMonth', {
+      axios.get(window.env.VITE_API_URL + '/api/operations/sumCategoriesByUserByMonth', {
         headers: {
           Authorization: 'Bearer ' + rootState.user.token
         },

--- a/front/src/store/user.ts
+++ b/front/src/store/user.ts
@@ -27,7 +27,7 @@ export default {
 
   actions: {
     fetchUser ({ state, commit }, userID) {
-      return fetchUser(userID, state.token, import.meta.env.VITE_API_URL)
+      return fetchUser(userID, state.token, window.env.VITE_API_URL)
         .then((response) => {
           commit('setUser', response)
         })

--- a/front/src/views/Config.vue
+++ b/front/src/views/Config.vue
@@ -91,7 +91,7 @@
 
   const store = useStore()
 
-  const apiURL = import.meta.env.VITE_API_URL
+  const apiURL = window.env.VITE_API_URL
 
   // Computed properties pour les textes dynamiques
   const maskAmountText = computed(() => {

--- a/front/src/views/Login.vue
+++ b/front/src/views/Login.vue
@@ -185,7 +185,7 @@
 
   watch(code, (value) => {
     if (value.length === 6) {
-      auth(value, import.meta.env.VITE_API_URL)
+      auth(value, window.env.VITE_API_URL)
         .then(({ userToken, userID }) => {
           endAuthentification({ userToken, userID })
         })
@@ -202,7 +202,7 @@
 
   checkUserAuthentification({
     userToken,
-    apiUrl: import.meta.env.VITE_API_URL
+    apiUrl: window.env.VITE_API_URL
   }).then((isExist) => {
     if (isExist) {
       endAuthentification({ userID, userToken })


### PR DESCRIPTION
Move API URL configuration from build-time import.meta.env to a
runtime config.js file loaded statically in index.html. This allows
changing the API URL without rebuilding the application.

- Add public/config.js defining window.env with VITE_API_URL
- Load config.js as a script tag in index.html before the app module
- Replace all import.meta.env.VITE_API_URL usages with window.env.VITE_API_URL
- Add Window.env TypeScript declaration in shims-vue.d.ts

https://claude.ai/code/session_016qA1HwvbEMzyFJD4ue227v