### PR TITLE
fix: restrict amortization card click to buttons only

### DIFF
--- a/front/src/components/Amortissement/Operation.vue
+++ b/front/src/components/Amortissement/Operation.vue
@@ -1,7 +1,6 @@
 <template>
   <div
     class="amortissement-card"
-    @click="toggleDetails"
   >
     <div class="card-header">
       <div class="operation-info">
@@ -39,6 +38,7 @@
           class="details-btn"
           :class="{ active: showDetails }"
           :title="showDetails ? 'Masquer les détails' : 'Afficher les détails'"
+          @click="toggleDetails"
         >
           <font-awesome-icon
             :icon="showDetails ? 'chevron-up' : 'chevron-down'"
@@ -245,7 +245,6 @@
 }
 
 .amortissement-card:hover {
-  transform: translateY(-4px);
   box-shadow: var(--shadow-xl);
 }
 


### PR DESCRIPTION
Move the toggleDetails click handler from the entire card div to the
details-btn button, preventing the card from closing when clicking
anywhere on its content area.

https://claude.ai/code/session_0188ptSmfnYzk5WekdFs7YPP