### PR TITLE
feat(front): add Eruda debug panel toggle in Config for iPad DevTools

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -29,6 +29,7 @@
     "@fortawesome/vue-fontawesome": "^3.1.3",
     "axios": "^1.13.0",
     "core-js": "^3.41.0",
+    "eruda": "^3.4.3",
     "highcharts": "^12.2.0",
     "register-service-worker": "^1.7.2",
     "universal-cookie": "^4.0.4",

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -30,6 +30,7 @@
   import { useRoute, useRouter } from 'vue-router'
   import { useStore } from 'vuex'
   import { useGlobalTheme } from '@/composables/useTheme'
+  import { useGlobalDebugTools } from '@/composables/useDebugTools'
 
   import NavBar from '@/components/NavBar.vue'
   import CompteList from '@/components/CompteList/index.vue'
@@ -43,6 +44,10 @@
 
   // Initialisation du système de thème
   useGlobalTheme()
+
+  // Initialisation des outils de debug (chargement conditionnel d'Eruda)
+  const { initDebugTools } = useGlobalDebugTools()
+  initDebugTools()
 
   const userID = computed(() => store.state.user.id)
   const displayAccountList = computed(() => store.state.display.account_list)

--- a/front/src/composables/useDebugTools.ts
+++ b/front/src/composables/useDebugTools.ts
@@ -44,7 +44,7 @@ export function useDebugTools () {
   return {
     isDebugEnabled: readonly(isDebugEnabled),
     initDebugTools,
-    toggleDebugTools,
+    toggleDebugTools
   }
 }
 

--- a/front/src/composables/useDebugTools.ts
+++ b/front/src/composables/useDebugTools.ts
@@ -1,0 +1,58 @@
+import { ref, readonly } from 'vue'
+
+const STORAGE_KEY = 'debugToolsEnabled'
+
+const isDebugEnabled = ref<boolean>(false)
+let erudaLoaded = false
+
+async function loadAndInitEruda () {
+  if (!erudaLoaded) {
+    const eruda = (await import('eruda')).default
+    eruda.init()
+    erudaLoaded = true
+  }
+}
+
+async function destroyEruda () {
+  if (erudaLoaded) {
+    const eruda = (await import('eruda')).default
+    eruda.destroy()
+    erudaLoaded = false
+  }
+}
+
+export function useDebugTools () {
+  const initDebugTools = async () => {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved === 'true') {
+      isDebugEnabled.value = true
+      await loadAndInitEruda()
+    }
+  }
+
+  const toggleDebugTools = async () => {
+    isDebugEnabled.value = !isDebugEnabled.value
+    localStorage.setItem(STORAGE_KEY, String(isDebugEnabled.value))
+
+    if (isDebugEnabled.value) {
+      await loadAndInitEruda()
+    } else {
+      await destroyEruda()
+    }
+  }
+
+  return {
+    isDebugEnabled: readonly(isDebugEnabled),
+    initDebugTools,
+    toggleDebugTools,
+  }
+}
+
+let debugInstance: ReturnType<typeof useDebugTools> | null = null
+
+export function useGlobalDebugTools () {
+  if (!debugInstance) {
+    debugInstance = useDebugTools()
+  }
+  return debugInstance
+}

--- a/front/src/plugins/fontawesome.ts
+++ b/front/src/plugins/fontawesome.ts
@@ -21,7 +21,10 @@ import {
   faSearchPlus,
   faChevronUp,
   faChevronDown,
-  faHamburger
+  faHamburger,
+  faBug,
+  faToggleOn,
+  faToggleOff
 } from '@fortawesome/free-solid-svg-icons'
 
 const FontAwesome = {
@@ -48,7 +51,10 @@ const FontAwesome = {
       faSearchPlus,
       faChevronUp,
       faChevronDown,
-      faHamburger
+      faHamburger,
+      faBug,
+      faToggleOn,
+      faToggleOff
     } as any)
   }
 }

--- a/front/src/views/Config.vue
+++ b/front/src/views/Config.vue
@@ -47,6 +47,30 @@
         </button>
       </div>
 
+      <div class="config-card">
+        <div class="card-header">
+          <div class="card-icon debug-icon">
+            <font-awesome-icon icon="bug" />
+          </div>
+          <div class="card-content">
+            <h3 class="card-title">
+              Outils de debug
+            </h3>
+            <p class="card-description">
+              Activer les DevTools (Eruda) pour inspecter les logs et les requêtes réseau sur iPad
+            </p>
+          </div>
+        </div>
+        <button
+          class="config-btn"
+          :class="isDebugEnabled ? 'debug-active-btn' : 'debug-btn'"
+          @click="toggleDebug"
+        >
+          <font-awesome-icon :icon="isDebugEnabled ? 'toggle-on' : 'toggle-off'" />
+          {{ isDebugEnabled ? 'Désactiver Eruda' : 'Activer Eruda' }}
+        </button>
+      </div>
+
       <div class="config-card logout-card">
         <div class="card-header">
           <div class="card-icon logout-icon">
@@ -88,8 +112,10 @@
   import { onMounted, computed } from 'vue'
   import { useStore } from 'vuex'
   import { removeCookies } from '@/services/auth'
+  import { useGlobalDebugTools } from '@/composables/useDebugTools'
 
   const store = useStore()
+  const { isDebugEnabled, toggleDebugTools } = useGlobalDebugTools()
 
   const apiURL = window.env.VITE_API_URL
 
@@ -106,6 +132,13 @@
 
   const toggleAmount = (event: Event) => {
     store.dispatch('toggleMaskAmount')
+    if (event.target instanceof HTMLElement) {
+      event.target.blur()
+    }
+  }
+
+  const toggleDebug = async (event: Event) => {
+    await toggleDebugTools()
     if (event.target instanceof HTMLElement) {
       event.target.blur()
     }
@@ -203,6 +236,11 @@
         background: rgba(220, 53, 69, 0.1);
         color: var(--color-danger);
       }
+
+      &.debug-icon {
+        background: rgba(111, 66, 193, 0.1);
+        color: #6f42c1;
+      }
     }
 
     .card-content {
@@ -292,6 +330,17 @@
       &:hover {
         box-shadow: var(--shadow-btn);
       }
+    }
+
+    &.debug-btn {
+      background: rgba(111, 66, 193, 0.1);
+      color: #6f42c1;
+      border: 1px solid rgba(111, 66, 193, 0.3);
+    }
+
+    &.debug-active-btn {
+      background: linear-gradient(135deg, #6f42c1 0%, #9c6fe4 100%);
+      color: white;
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       core-js:
         specifier: ^3.41.0
         version: 3.49.0
+      eruda:
+        specifier: ^3.4.3
+        version: 3.4.3
       highcharts:
         specifier: ^12.2.0
         version: 12.6.0
@@ -2621,6 +2624,9 @@ packages:
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  eruda@3.4.3:
+    resolution: {integrity: sha512-J2TsF4dXSspOXev5bJ6mljv0dRrxj21wklrDzbvPmYaEmVoC+2psylyRi70nUPFh1mTQfIBsSusUtAMZtUN+/w==}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -8800,6 +8806,8 @@ snapshots:
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
+
+  eruda@3.4.3: {}
 
   es-abstract@1.24.2:
     dependencies:


### PR DESCRIPTION
Adds a toggle in the configuration page to enable/disable Eruda,
an in-browser DevTools panel showing console logs and network requests.
Eruda is loaded dynamically (dynamic import) to keep the production
bundle unaffected when the feature is disabled. The enabled state
persists across sessions via localStorage.

https://claude.ai/code/session_01PNRNX1iVaM8K6ZUKnzjWeK