### PR TITLE
feat: allow users to edit their account info from settings

### DIFF
--- a/back/src/controllers/user.controller.ts
+++ b/back/src/controllers/user.controller.ts
@@ -11,6 +11,7 @@ import {
   get,
   getModelSchemaRef,
   HttpErrors,
+  patch,
   post,
   requestBody,
   SchemaObject,
@@ -113,15 +114,80 @@ export class UserController {
   async whoAmI(
     @inject(SecurityBindings.USER)
     currentUserProfile: UserProfile,
-  ): Promise<{favoris?: number; warningTotal?: number; IDuser: number}> {
-    const {favoris, warningTotal, IDuser} = await this.userService.findUserById(
-      currentUserProfile[securityId],
-    );
+  ): Promise<{
+    favoris?: number;
+    warningTotal?: number;
+    warningCompte?: number;
+    IDuser: number;
+    email: string;
+    username?: string;
+  }> {
+    const {favoris, warningTotal, warningCompte, IDuser, email, username} =
+      await this.userService.findUserById(currentUserProfile[securityId]);
     return {
       favoris,
       warningTotal,
+      warningCompte,
       IDuser,
+      email,
+      username,
     };
+  }
+
+  @authenticate('jwt')
+  @patch('/users/me', {
+    responses: {
+      '204': {
+        description: 'Update current user info',
+      },
+    },
+  })
+  async updateMe(
+    @inject(SecurityBindings.USER)
+    currentUserProfile: UserProfile,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              email: {type: 'string'},
+              username: {type: 'string'},
+              warningTotal: {type: 'number'},
+              warningCompte: {type: 'number'},
+              favoris: {type: 'number'},
+            },
+            additionalProperties: false,
+          },
+        },
+      },
+    })
+    updates: Partial<
+      Pick<
+        User,
+        'email' | 'username' | 'warningTotal' | 'warningCompte' | 'favoris'
+      >
+    >,
+  ): Promise<void> {
+    const userId = currentUserProfile[securityId];
+    const allowed = _.pick(updates, [
+      'email',
+      'username',
+      'warningTotal',
+      'warningCompte',
+      'favoris',
+    ]);
+
+    if (allowed.email) {
+      const existingByEmail = await this.userRepository.findOne({
+        where: {email: allowed.email},
+      });
+      if (existingByEmail && existingByEmail.id !== userId) {
+        throw new HttpErrors.Conflict('A user with this email already exists');
+      }
+    }
+
+    await this.userRepository.updateById(userId, allowed);
   }
 
   @authenticate('jwt')

--- a/front/src/plugins/fontawesome.ts
+++ b/front/src/plugins/fontawesome.ts
@@ -25,7 +25,14 @@ import {
   faHamburger,
   faBug,
   faToggleOn,
-  faToggleOff
+  faToggleOff,
+  faUserEdit,
+  faUserCog,
+  faSave,
+  faSpinner,
+  faInfoCircle,
+  faExclamationCircle,
+  faCheckCircle
 } from '@fortawesome/free-solid-svg-icons'
 
 const FontAwesome = {
@@ -56,7 +63,14 @@ const FontAwesome = {
       faHamburger,
       faBug,
       faToggleOn,
-      faToggleOff
+      faToggleOff,
+      faUserEdit,
+      faUserCog,
+      faSave,
+      faSpinner,
+      faInfoCircle,
+      faExclamationCircle,
+      faCheckCircle
     } as any)
   }
 }

--- a/front/src/router.ts
+++ b/front/src/router.ts
@@ -4,6 +4,7 @@ const Home = () => import(/* webpackChunkName: "home" */ './views/Home.vue')
 const Stats = () => import(/* webpackChunkName: "stats" */ './views/Stats.vue')
 const Login = () => import(/* webpackChunkName: "login" */ './views/Login.vue')
 const Config = () => import(/* webpackChunkName: "config" */ './views/Config.vue')
+const EditUser = () => import(/* webpackChunkName: "edituser" */ './views/EditUser.vue')
 const OperationsRecurrentes = () => import(/* webpackChunkName: "operecur" */ './views/OperationsRecurrentes.vue')
 const Amortissement = () => import(/* webpackChunkName: "operecur" */ './views/Amortissement.vue')
 const Credits = () => import(/* webpackChunkName: "credits" */ './views/Credits.vue')
@@ -120,6 +121,13 @@ export default createRouter({
     path: '/config',
     name: 'Config',
     component: Config,
+    meta: {
+      disabledTotalHeader: true
+    }
+  }, {
+    path: '/editUser',
+    name: 'Mon compte',
+    component: EditUser,
     meta: {
       disabledTotalHeader: true
     }

--- a/front/src/services/user.ts
+++ b/front/src/services/user.ts
@@ -6,12 +6,30 @@ export const fetchUser = (_, userToken, apiUrl) => {
       Authorization: 'Bearer ' + userToken
     }
   }).then((response) => {
-    return { id: response.data.IDuser, favoris: response.data.favoris, warningTotal: response.data.warningTotal }
+    return {
+      id: response.data.IDuser,
+      favoris: response.data.favoris,
+      warningTotal: response.data.warningTotal,
+      warningCompte: response.data.warningCompte,
+      email: response.data.email,
+      username: response.data.username
+    }
+  }).catch((error) => {
+    throw new Error(error)
+  })
+}
+
+export const updateUser = (updates, userToken, apiUrl) => {
+  return axios.patch(apiUrl + '/api/users/me', updates, {
+    headers: {
+      Authorization: 'Bearer ' + userToken
+    }
   }).catch((error) => {
     throw new Error(error)
   })
 }
 
 export default {
-  fetchUser
+  fetchUser,
+  updateUser
 }

--- a/front/src/store/user.ts
+++ b/front/src/store/user.ts
@@ -1,19 +1,25 @@
-import { fetchUser } from '@/services/user'
+import { fetchUser, updateUser } from '@/services/user'
 
 export default {
   state: {
     id: null,
     favoris: null,
     warningTotal: null,
+    warningCompte: null,
+    email: null,
+    username: null,
     token: null,
     maskAmount: false
   },
 
   mutations: {
-    setUser (state, { id, favoris, warningTotal }) {
+    setUser (state, { id, favoris, warningTotal, warningCompte, email, username }) {
       state.id = id
       state.favoris = favoris
       state.warningTotal = warningTotal
+      state.warningCompte = warningCompte
+      state.email = email
+      state.username = username
     },
 
     setToken (state, token) {
@@ -31,6 +37,11 @@ export default {
         .then((response) => {
           commit('setUser', response)
         })
+    },
+
+    updateUser ({ state, dispatch }, updates) {
+      return updateUser(updates, state.token, window.env.VITE_API_URL)
+        .then(() => dispatch('fetchUser', state.id))
     },
 
     saveUserToken ({ commit }, token) {

--- a/front/src/views/Config.vue
+++ b/front/src/views/Config.vue
@@ -26,6 +26,29 @@
 
       <div class="config-card">
         <div class="card-header">
+          <div class="card-icon account-icon">
+            <font-awesome-icon icon="user-cog" />
+          </div>
+          <div class="card-content">
+            <h3 class="card-title">
+              Mon compte
+            </h3>
+            <p class="card-description">
+              Modifier les informations de votre compte utilisateur
+            </p>
+          </div>
+        </div>
+        <router-link
+          class="config-btn account-btn"
+          to="/editUser"
+        >
+          <font-awesome-icon icon="user-edit" />
+          Modifier mes informations
+        </router-link>
+      </div>
+
+      <div class="config-card">
+        <div class="card-header">
           <div class="card-icon privacy-icon">
             <font-awesome-icon icon="eye-slash" />
           </div>
@@ -241,6 +264,11 @@
         background: rgba(111, 66, 193, 0.1);
         color: #6f42c1;
       }
+
+      &.account-icon {
+        background: rgba(102, 126, 234, 0.1);
+        color: #667eea;
+      }
     }
 
     .card-content {
@@ -340,6 +368,11 @@
 
     &.debug-active-btn {
       background: linear-gradient(135deg, #6f42c1 0%, #9c6fe4 100%);
+      color: white;
+    }
+
+    &.account-btn {
+      background: var(--primary-gradient);
       color: white;
     }
   }

--- a/front/src/views/Config.vue
+++ b/front/src/views/Config.vue
@@ -266,8 +266,8 @@
       }
 
       &.account-icon {
-        background: rgba(102, 126, 234, 0.1);
-        color: #667eea;
+        background: rgba(40, 167, 69, 0.1);
+        color: var(--color-success);
       }
     }
 
@@ -372,7 +372,7 @@
     }
 
     &.account-btn {
-      background: var(--primary-gradient);
+      background: var(--success-gradient);
       color: white;
     }
   }

--- a/front/src/views/EditUser.vue
+++ b/front/src/views/EditUser.vue
@@ -1,0 +1,377 @@
+<template>
+  <div class="edit-user">
+    <div class="form-card">
+      <div class="form-header">
+        <div class="header-icon">
+          <font-awesome-icon icon="user-edit" />
+        </div>
+        <h2 class="form-title">
+          Modifier mes informations
+        </h2>
+        <p class="form-subtitle">
+          Mettez à jour les informations de votre compte
+        </p>
+      </div>
+
+      <form
+        class="form-body"
+        @submit.prevent="submit"
+      >
+        <div class="form-group">
+          <label
+            for="user-username"
+            class="form-label"
+          >Nom d'utilisateur</label>
+          <input
+            id="user-username"
+            v-model="form.username"
+            type="text"
+            class="form-input"
+            placeholder="Votre nom d'utilisateur"
+          >
+        </div>
+
+        <div class="form-group">
+          <label
+            for="user-email"
+            class="form-label"
+          >Email</label>
+          <input
+            id="user-email"
+            v-model="form.email"
+            type="email"
+            class="form-input"
+            placeholder="vous@exemple.com"
+            required
+          >
+        </div>
+
+        <div class="form-row">
+          <div class="form-group">
+            <label
+              for="user-warning-total"
+              class="form-label"
+            >Seuil d'alerte total</label>
+            <input
+              id="user-warning-total"
+              v-model.number="form.warningTotal"
+              type="number"
+              class="form-input"
+              step="0.01"
+              placeholder="0"
+            >
+          </div>
+
+          <div class="form-group">
+            <label
+              for="user-warning-compte"
+              class="form-label"
+            >Seuil d'alerte par compte</label>
+            <input
+              id="user-warning-compte"
+              v-model.number="form.warningCompte"
+              type="number"
+              class="form-input"
+              step="0.01"
+              placeholder="0"
+            >
+          </div>
+        </div>
+
+        <div
+          v-if="errorMessage"
+          class="form-error"
+        >
+          <font-awesome-icon icon="exclamation-circle" />
+          {{ errorMessage }}
+        </div>
+
+        <div
+          v-if="successMessage"
+          class="form-success"
+        >
+          <font-awesome-icon icon="check-circle" />
+          {{ successMessage }}
+        </div>
+
+        <p class="form-info">
+          <font-awesome-icon icon="info-circle" />
+          La modification du code d'accès sera disponible prochainement.
+        </p>
+
+        <div class="form-actions">
+          <button
+            type="button"
+            class="btn btn-secondary"
+            @click="cancel"
+          >
+            Annuler
+          </button>
+          <button
+            type="submit"
+            class="btn btn-primary"
+            :disabled="isSubmitting || !isFormValid"
+          >
+            <font-awesome-icon
+              v-if="isSubmitting"
+              icon="spinner"
+              spin
+            />
+            <font-awesome-icon
+              v-else
+              icon="save"
+            />
+            {{ isSubmitting ? 'Enregistrement...' : 'Enregistrer' }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { computed, onMounted, reactive, ref } from 'vue'
+  import { useRouter } from 'vue-router'
+  import { useStore } from 'vuex'
+
+  const store = useStore()
+  const router = useRouter()
+
+  const form = reactive({
+    username: '' as string,
+    email: '' as string,
+    warningTotal: null as number | null,
+    warningCompte: null as number | null
+  })
+
+  const isSubmitting = ref(false)
+  const errorMessage = ref('')
+  const successMessage = ref('')
+
+  const isFormValid = computed(() => {
+    return form.email && form.email.trim().length > 0
+  })
+
+  const loadUser = () => {
+    form.username = store.state.user.username || ''
+    form.email = store.state.user.email || ''
+    form.warningTotal = store.state.user.warningTotal
+    form.warningCompte = store.state.user.warningCompte
+  }
+
+  onMounted(() => {
+    store.commit('setActiveAccount', { NomCompte: 'Mon compte' })
+
+    if (store.state.user.email) {
+      loadUser()
+    } else if (store.state.user.id) {
+      store.dispatch('fetchUser', store.state.user.id).then(loadUser)
+    }
+  })
+
+  const submit = async () => {
+    errorMessage.value = ''
+    successMessage.value = ''
+    if (!isFormValid.value) return
+
+    isSubmitting.value = true
+    try {
+      await store.dispatch('updateUser', {
+        username: form.username || undefined,
+        email: form.email,
+        warningTotal: form.warningTotal,
+        warningCompte: form.warningCompte
+      })
+      successMessage.value = 'Vos informations ont été mises à jour.'
+    } catch (err) {
+      const status = (err as { response?: { status?: number } })?.response?.status
+      if (status === 409) {
+        errorMessage.value = 'Cet email est déjà utilisé par un autre compte.'
+      } else {
+        errorMessage.value = 'Impossible de mettre à jour vos informations. Veuillez réessayer.'
+      }
+    } finally {
+      isSubmitting.value = false
+    }
+  }
+
+  const cancel = () => {
+    router.push('/config')
+  }
+</script>
+
+<style lang="scss" scoped>
+.edit-user {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: var(--spacing-2xl) var(--spacing-lg);
+}
+
+.form-card {
+  background: var(--bg-glass);
+  backdrop-filter: blur(20px);
+  border-radius: var(--radius-2xl);
+  padding: var(--spacing-2xl);
+  box-shadow: var(--shadow-xl);
+  border: var(--glass-border);
+}
+
+.form-header {
+  text-align: center;
+  margin-bottom: var(--spacing-2xl);
+
+  .header-icon {
+    width: 64px;
+    height: 64px;
+    margin: 0 auto var(--spacing-lg);
+    border-radius: 50%;
+    background: var(--primary-gradient);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-size: 1.5rem;
+    box-shadow: var(--shadow-glass);
+  }
+
+  .form-title {
+    font-size: 1.5rem;
+    font-weight: var(--font-weight-bold);
+    color: var(--text-primary);
+    margin: 0 0 var(--spacing-sm) 0;
+  }
+
+  .form-subtitle {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    margin: 0;
+  }
+}
+
+.form-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-lg);
+
+  @media (max-width: 600px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.form-label {
+  font-size: 0.9rem;
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+}
+
+.form-input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 2px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  font-size: 1rem;
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  transition: all var(--transition-normal);
+
+  &:focus {
+    outline: none;
+    border-color: var(--color-primary, #667eea);
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.15);
+  }
+}
+
+.form-error,
+.form-success {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-lg);
+  font-size: 0.9rem;
+  font-weight: var(--font-weight-medium);
+}
+
+.form-error {
+  color: var(--color-danger-dark);
+  background: var(--bg-danger-light);
+  border: 1px solid rgba(254, 178, 178, 0.4);
+}
+
+.form-success {
+  color: #1f7a3a;
+  background: rgba(40, 167, 69, 0.12);
+  border: 1px solid rgba(40, 167, 69, 0.3);
+}
+
+.form-info {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.form-actions {
+  display: flex;
+  gap: var(--spacing-md);
+  margin-top: var(--spacing-md);
+
+  @media (max-width: 600px) {
+    flex-direction: column-reverse;
+  }
+}
+
+.btn {
+  flex: 1;
+  padding: 0.875rem 1.5rem;
+  border: none;
+  border-radius: var(--radius-xl);
+  font-size: 1rem;
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: all var(--transition-smooth);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  &.btn-primary {
+    background: var(--primary-gradient);
+    color: white;
+
+    &:hover:not(:disabled) {
+      transform: translateY(-2px);
+      box-shadow: var(--shadow-btn);
+    }
+  }
+
+  &.btn-secondary {
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    border: 2px solid var(--border-color);
+
+    &:hover {
+      background: var(--bg-muted);
+    }
+  }
+}
+</style>

--- a/front/src/views/EditUser.vue
+++ b/front/src/views/EditUser.vue
@@ -87,9 +87,13 @@
             id="user-favoris"
             v-model="form.favoris"
             class="form-input"
+            required
           >
-            <option :value="null">
-              Aucun
+            <option
+              :value="null"
+              disabled
+            >
+              Sélectionnez un compte
             </option>
             <option
               v-for="account in accountList"
@@ -177,7 +181,12 @@
   const successMessage = ref('')
 
   const isFormValid = computed(() => {
-    return form.email && form.email.trim().length > 0
+    return (
+      form.email &&
+      form.email.trim().length > 0 &&
+      form.favoris !== null &&
+      form.favoris !== undefined
+    )
   })
 
   const loadUser = () => {

--- a/front/src/views/EditUser.vue
+++ b/front/src/views/EditUser.vue
@@ -78,6 +78,29 @@
           </div>
         </div>
 
+        <div class="form-group">
+          <label
+            for="user-favoris"
+            class="form-label"
+          >Compte favori</label>
+          <select
+            id="user-favoris"
+            v-model="form.favoris"
+            class="form-input"
+          >
+            <option :value="null">
+              Aucun
+            </option>
+            <option
+              v-for="account in accountList"
+              :key="'favoris-' + account.IDcompte"
+              :value="account.IDcompte"
+            >
+              {{ account.NomCompte }}
+            </option>
+          </select>
+        </div>
+
         <div
           v-if="errorMessage"
           class="form-error"
@@ -141,8 +164,13 @@
     username: '' as string,
     email: '' as string,
     warningTotal: null as number | null,
-    warningCompte: null as number | null
+    warningCompte: null as number | null,
+    favoris: null as number | null
   })
+
+  const accountList = computed(() =>
+    (store.state.compte.accountList || []).filter((account) => account.visible)
+  )
 
   const isSubmitting = ref(false)
   const errorMessage = ref('')
@@ -157,6 +185,7 @@
     form.email = store.state.user.email || ''
     form.warningTotal = store.state.user.warningTotal
     form.warningCompte = store.state.user.warningCompte
+    form.favoris = store.state.user.favoris ?? null
   }
 
   onMounted(() => {
@@ -180,7 +209,8 @@
         username: form.username || undefined,
         email: form.email,
         warningTotal: form.warningTotal,
-        warningCompte: form.warningCompte
+        warningCompte: form.warningCompte,
+        favoris: form.favoris
       })
       successMessage.value = 'Vos informations ont été mises à jour.'
     } catch (err) {


### PR DESCRIPTION
Adds a PATCH /users/me endpoint that updates the current user's
email, username, warningTotal, warningCompte, and favoris fields
(secret_key changes will be handled later). The settings page now
exposes a "Mon compte" card linking to a new EditUser form bound
to a Vuex updateUser action.