### PR TITLE
feat: add real estate property management

### DIFF
--- a/back/migrations/2026-05-02-create-bien.sql
+++ b/back/migrations/2026-05-02-create-bien.sql
@@ -1,0 +1,25 @@
+-- Migration: create Bien table for real estate property management
+-- Date: 2026-05-02
+
+CREATE TABLE IF NOT EXISTS `Bien` (
+  `IDbien` INT NOT NULL AUTO_INCREMENT,
+  `NomBien` VARCHAR(512) NOT NULL,
+  `Ville` VARCHAR(512) NOT NULL,
+  `TypeBien` VARCHAR(512) NOT NULL,
+  `Surface` FLOAT NULL DEFAULT NULL,
+  `Usage` VARCHAR(512) NOT NULL DEFAULT 'principale',
+  `DateAchat` DATETIME NOT NULL,
+  `PrixBienNu` FLOAT NOT NULL,
+  `FraisNotaire` FLOAT NOT NULL,
+  `FraisAgence` FLOAT NULL DEFAULT 0,
+  `ApportCash` FLOAT NULL DEFAULT 0,
+  `ValeurActuelle` FLOAT NULL DEFAULT NULL,
+  `IDcredit` INT NULL DEFAULT NULL,
+  `IDuser` INT NOT NULL,
+  PRIMARY KEY (`IDbien`),
+  KEY `idx_bien_iduser` (`IDuser`),
+  KEY `idx_bien_idcredit` (`IDcredit`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Rollback:
+-- DROP TABLE IF EXISTS `Bien`;

--- a/back/src/controllers/bien.controller.ts
+++ b/back/src/controllers/bien.controller.ts
@@ -1,0 +1,263 @@
+import {
+  Count,
+  CountSchema,
+  Filter,
+  FilterExcludingWhere,
+  repository,
+  Where,
+} from '@loopback/repository';
+import {
+  post,
+  param,
+  get,
+  getModelSchemaRef,
+  patch,
+  put,
+  del,
+  requestBody,
+  HttpErrors,
+} from '@loopback/rest';
+import {Bien} from '../models';
+import {BienRepository, CreditRepository} from '../repositories';
+import {authenticate} from '@loopback/authentication';
+import {inject} from '@loopback/core';
+import {SecurityBindings, UserProfile} from '@loopback/security';
+import {getCurrentUserId} from '../services/current-user';
+
+@authenticate('jwt')
+export class BienController {
+  constructor(
+    @repository(BienRepository)
+    public bienRepository: BienRepository,
+    @repository(CreditRepository)
+    public creditRepository: CreditRepository,
+  ) {}
+
+  private scope(
+    currentUserProfile: UserProfile,
+    where?: Where<Bien>,
+  ): Where<Bien> {
+    const IDuser = getCurrentUserId(currentUserProfile);
+    const userScope: Where<Bien> = {IDuser};
+    return where ? {and: [where, userScope]} : userScope;
+  }
+
+  private async assertOwned(
+    id: number,
+    currentUserProfile: UserProfile,
+  ): Promise<Bien> {
+    const IDuser = getCurrentUserId(currentUserProfile);
+    const bien = await this.bienRepository.findOne({
+      where: {IDbien: id, IDuser},
+    });
+    if (!bien) {
+      throw new HttpErrors.NotFound(`Bien ${id} not found`);
+    }
+    return bien;
+  }
+
+  private async assertCreditOwned(
+    creditID: number,
+    currentUserProfile: UserProfile,
+  ): Promise<void> {
+    const IDuser = getCurrentUserId(currentUserProfile);
+    const credit = await this.creditRepository.findOne({
+      where: {IDcredit: creditID, IDuser},
+    });
+    if (!credit) {
+      throw new HttpErrors.NotFound(`Credit ${creditID} not found`);
+    }
+  }
+
+  @post('/biens', {
+    responses: {
+      '200': {
+        description: 'Bien model instance',
+        content: {'application/json': {schema: getModelSchemaRef(Bien)}},
+      },
+    },
+  })
+  async create(
+    @inject(SecurityBindings.USER)
+    currentUserProfile: UserProfile,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Bien, {
+            title: 'NewBien',
+            exclude: ['IDbien', 'IDuser'],
+          }),
+        },
+      },
+    })
+    bien: Omit<Bien, 'IDbien' | 'IDuser'>,
+  ): Promise<Bien> {
+    const userID = getCurrentUserId(currentUserProfile);
+    if (bien.IDcredit) {
+      await this.assertCreditOwned(bien.IDcredit, currentUserProfile);
+    }
+    return this.bienRepository.create({
+      ...bien,
+      IDuser: userID,
+    });
+  }
+
+  @get('/biens/count', {
+    responses: {
+      '200': {
+        description: 'Bien model count',
+        content: {'application/json': {schema: CountSchema}},
+      },
+    },
+  })
+  async count(
+    @inject(SecurityBindings.USER) currentUserProfile: UserProfile,
+    @param.where(Bien) where?: Where<Bien>,
+  ): Promise<Count> {
+    return this.bienRepository.count(this.scope(currentUserProfile, where));
+  }
+
+  @get('/biens', {
+    responses: {
+      '200': {
+        description: 'Array of Bien model instances',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'array',
+              items: getModelSchemaRef(Bien, {includeRelations: true}),
+            },
+          },
+        },
+      },
+    },
+  })
+  async find(
+    @inject(SecurityBindings.USER)
+    currentUserProfile: UserProfile,
+    @param.filter(Bien) filter?: Filter<Bien>,
+  ): Promise<Bien[]> {
+    return this.bienRepository.find({
+      ...filter,
+      where: this.scope(currentUserProfile, filter?.where),
+    });
+  }
+
+  @patch('/biens', {
+    responses: {
+      '200': {
+        description: 'Bien PATCH success count',
+        content: {'application/json': {schema: CountSchema}},
+      },
+    },
+  })
+  async updateAll(
+    @inject(SecurityBindings.USER) currentUserProfile: UserProfile,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Bien, {
+            partial: true,
+            exclude: ['IDuser'],
+          }),
+        },
+      },
+    })
+    bien: Omit<Bien, 'IDuser'>,
+    @param.where(Bien) where?: Where<Bien>,
+  ): Promise<Count> {
+    if (bien.IDcredit) {
+      await this.assertCreditOwned(bien.IDcredit, currentUserProfile);
+    }
+    return this.bienRepository.updateAll(
+      bien,
+      this.scope(currentUserProfile, where),
+    );
+  }
+
+  @get('/biens/{id}', {
+    responses: {
+      '200': {
+        description: 'Bien model instance',
+        content: {
+          'application/json': {
+            schema: getModelSchemaRef(Bien, {includeRelations: true}),
+          },
+        },
+      },
+    },
+  })
+  async findById(
+    @inject(SecurityBindings.USER) currentUserProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @param.filter(Bien, {exclude: 'where'})
+    filter?: FilterExcludingWhere<Bien>,
+  ): Promise<Bien> {
+    await this.assertOwned(id, currentUserProfile);
+    return this.bienRepository.findById(id, filter);
+  }
+
+  @patch('/biens/{id}', {
+    responses: {
+      '204': {
+        description: 'Bien PATCH success',
+      },
+    },
+  })
+  async updateById(
+    @inject(SecurityBindings.USER) currentUserProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Bien, {
+            partial: true,
+            exclude: ['IDuser'],
+          }),
+        },
+      },
+    })
+    bien: Omit<Bien, 'IDuser'>,
+  ): Promise<void> {
+    await this.assertOwned(id, currentUserProfile);
+    if (bien.IDcredit) {
+      await this.assertCreditOwned(bien.IDcredit, currentUserProfile);
+    }
+    await this.bienRepository.updateById(id, bien);
+  }
+
+  @put('/biens/{id}', {
+    responses: {
+      '204': {
+        description: 'Bien PUT success',
+      },
+    },
+  })
+  async replaceById(
+    @inject(SecurityBindings.USER) currentUserProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody() bien: Bien,
+  ): Promise<void> {
+    await this.assertOwned(id, currentUserProfile);
+    if (bien.IDcredit) {
+      await this.assertCreditOwned(bien.IDcredit, currentUserProfile);
+    }
+    bien.IDuser = getCurrentUserId(currentUserProfile);
+    await this.bienRepository.replaceById(id, bien);
+  }
+
+  @del('/biens/{id}', {
+    responses: {
+      '204': {
+        description: 'Bien DELETE success',
+      },
+    },
+  })
+  async deleteById(
+    @inject(SecurityBindings.USER) currentUserProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<void> {
+    await this.assertOwned(id, currentUserProfile);
+    await this.bienRepository.deleteById(id);
+  }
+}

--- a/back/src/controllers/index.ts
+++ b/back/src/controllers/index.ts
@@ -7,4 +7,5 @@ export * from './compte-banque.controller';
 export * from './operation.controller';
 export * from './operation-recurrente.controller';
 export * from './credit.controller';
+export * from './bien.controller';
 export * from './user.controller';

--- a/back/src/models/bien.model.ts
+++ b/back/src/models/bien.model.ts
@@ -1,0 +1,119 @@
+import {Entity, model, property} from '@loopback/repository';
+
+@model({
+  settings: {
+    strict: true,
+    forceId: false,
+    validateUpsert: true,
+    plural: 'Biens',
+    idInjection: false,
+  },
+})
+export class Bien extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    generated: true,
+  })
+  IDbien?: number;
+
+  @property({
+    type: 'string',
+    required: true,
+  })
+  NomBien: string;
+
+  @property({
+    type: 'string',
+    required: true,
+  })
+  Ville: string;
+
+  @property({
+    type: 'string',
+    required: true,
+  })
+  TypeBien: string;
+
+  @property({
+    type: 'number',
+    required: false,
+    dataType: 'FLOAT',
+  })
+  Surface?: number;
+
+  @property({
+    type: 'string',
+    required: true,
+    default: 'principale',
+  })
+  Usage: string;
+
+  @property({
+    type: 'date',
+    required: true,
+  })
+  DateAchat: string;
+
+  @property({
+    type: 'number',
+    required: true,
+    dataType: 'FLOAT',
+  })
+  PrixBienNu: number;
+
+  @property({
+    type: 'number',
+    required: true,
+    dataType: 'FLOAT',
+  })
+  FraisNotaire: number;
+
+  @property({
+    type: 'number',
+    required: false,
+    dataType: 'FLOAT',
+    default: 0,
+  })
+  FraisAgence?: number;
+
+  @property({
+    type: 'number',
+    required: false,
+    dataType: 'FLOAT',
+    default: 0,
+  })
+  ApportCash?: number;
+
+  @property({
+    type: 'number',
+    required: false,
+    dataType: 'FLOAT',
+  })
+  ValeurActuelle?: number;
+
+  @property({
+    type: 'number',
+    required: false,
+  })
+  IDcredit?: number;
+
+  @property({
+    type: 'number',
+    required: true,
+  })
+  IDuser: number;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [prop: string]: any;
+
+  constructor(data?: Partial<Bien>) {
+    super(data);
+  }
+}
+
+export interface BienRelations {
+  // describe navigational properties here
+}
+
+export type BienWithRelations = Bien & BienRelations;

--- a/back/src/models/index.ts
+++ b/back/src/models/index.ts
@@ -5,5 +5,6 @@ export * from './compte.model';
 export * from './operation.model';
 export * from './operation-recurrente.model';
 export * from './credit.model';
+export * from './bien.model';
 export * from './user.model';
 export * from './user-credentials.model';

--- a/back/src/repositories/bien.repository.ts
+++ b/back/src/repositories/bien.repository.ts
@@ -1,0 +1,16 @@
+import {DefaultCrudRepository} from '@loopback/repository';
+import {Bien, BienRelations} from '../models';
+import {MccbMysqlDataSource} from '../datasources';
+import {inject} from '@loopback/core';
+
+export class BienRepository extends DefaultCrudRepository<
+  Bien,
+  typeof Bien.prototype.IDbien,
+  BienRelations
+> {
+  constructor(
+    @inject('datasources.mccb_mysql') dataSource: MccbMysqlDataSource,
+  ) {
+    super(Bien, dataSource);
+  }
+}

--- a/back/src/repositories/index.ts
+++ b/back/src/repositories/index.ts
@@ -5,5 +5,6 @@ export * from './compte.repository';
 export * from './operation.repository';
 export * from './operation-recurrente.repository';
 export * from './credit.repository';
+export * from './bien.repository';
 export * from './user-credentials.repository';
 export * from './user.repository';

--- a/front/src/components/BienCard.vue
+++ b/front/src/components/BienCard.vue
@@ -1,0 +1,278 @@
+<template>
+  <div
+    class="bien-card"
+    @click="editBien"
+  >
+    <div class="bien-card-header">
+      <h3 class="bien-name">
+        {{ bien.NomBien }}
+      </h3>
+      <span class="bien-type">
+        {{ typeLabel }}
+      </span>
+    </div>
+
+    <div class="bien-card-body">
+      <div class="bien-info">
+        <font-awesome-icon
+          icon="map-marker-alt"
+          class="icon"
+        />
+        <span>{{ bien.Ville }}</span>
+        <span
+          v-if="bien.Surface"
+          class="bien-surface"
+        >· {{ bien.Surface }} m²</span>
+      </div>
+
+      <div class="bien-info">
+        <font-awesome-icon
+          icon="home"
+          class="icon"
+        />
+        <span>{{ usageLabel }}</span>
+      </div>
+
+      <div class="bien-info">
+        <font-awesome-icon
+          icon="calendar"
+          class="icon"
+        />
+        <span>Acheté le {{ formatDate(bien.DateAchat) }}</span>
+      </div>
+
+      <div class="bien-amounts">
+        <div class="amount-item">
+          <span class="label">Prix total</span>
+          <span class="value">{{ formatAmount(prixTotal) }}</span>
+        </div>
+        <div
+          v-if="bien.ValeurActuelle"
+          class="amount-item"
+        >
+          <span class="label">Valeur actuelle</span>
+          <span
+            class="value"
+            :class="plusValueClass"
+          >{{ formatAmount(bien.ValeurActuelle) }}</span>
+        </div>
+      </div>
+
+      <div
+        v-if="associatedCredit"
+        class="bien-info"
+      >
+        <font-awesome-icon
+          icon="credit-card"
+          class="icon"
+        />
+        <span>Crédit : {{ associatedCredit.NomCredit }}</span>
+      </div>
+
+      <div
+        v-if="bien.ApportCash"
+        class="bien-info"
+      >
+        <font-awesome-icon
+          icon="wallet"
+          class="icon"
+        />
+        <span>Apport : {{ formatAmount(bien.ApportCash) }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+  import { computed } from 'vue'
+  import { useRouter } from 'vue-router'
+  import { useStore } from 'vuex'
+
+  const props = defineProps({
+    bien: {
+      type: Object,
+      required: true
+    }
+  })
+
+  const router = useRouter()
+  const store = useStore()
+
+  const prixTotal = computed(() => {
+    return (
+      (props.bien.PrixBienNu || 0) +
+      (props.bien.FraisNotaire || 0) +
+      (props.bien.FraisAgence || 0)
+    )
+  })
+
+  const associatedCredit = computed(() => {
+    if (!props.bien.IDcredit) return null
+    return store.state.credit.creditList?.find(
+      (c) => c.IDcredit === props.bien.IDcredit
+    )
+  })
+
+  const typeLabel = computed(() => {
+    const labels = {
+      appartement: 'Appartement',
+      maison: 'Maison',
+      terrain: 'Terrain',
+      parking: 'Parking',
+      local: 'Local commercial'
+    }
+    return labels[props.bien.TypeBien] || props.bien.TypeBien
+  })
+
+  const usageLabel = computed(() => {
+    const labels = {
+      principale: 'Résidence principale',
+      secondaire: 'Résidence secondaire',
+      locatif: 'Locatif'
+    }
+    return labels[props.bien.Usage] || props.bien.Usage
+  })
+
+  const plusValueClass = computed(() => {
+    if (!props.bien.ValeurActuelle) return ''
+    if (props.bien.ValeurActuelle > prixTotal.value) return 'montant-positif'
+    if (props.bien.ValeurActuelle < prixTotal.value) return 'montant-negatif'
+    return ''
+  })
+
+  const formatAmount = (amount) => {
+    if (amount === undefined || amount === null) return '0,00 €'
+    return new Intl.NumberFormat('fr-FR', {
+      style: 'currency',
+      currency: 'EUR'
+    }).format(amount)
+  }
+
+  const formatDate = (dateString) => {
+    if (!dateString) return ''
+    const date = new Date(dateString)
+    return new Intl.DateTimeFormat('fr-FR', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    }).format(date)
+  }
+
+  const editBien = () => {
+    router.push(`/editBien/${props.bien.IDbien}`)
+  }
+</script>
+
+<style scoped>
+.bien-card {
+  background: var(--bg-card, #ffffff);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+  box-shadow: var(--shadow-md, 0 4px 6px rgba(0, 0, 0, 0.1));
+  cursor: pointer;
+  transition: all 0.3s ease;
+  border: 1px solid var(--border-color, #e0e0e0);
+}
+
+.bien-card:hover {
+  box-shadow: var(--shadow-lg, 0 10px 15px rgba(0, 0, 0, 0.1));
+  transform: translateY(-2px);
+}
+
+.bien-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border-color, #e0e0e0);
+}
+
+.bien-name {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-primary, #333);
+  margin: 0;
+}
+
+.bien-type {
+  padding: 0.25rem 0.75rem;
+  border-radius: 20px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  background-color: #ede7f6;
+  color: #5e35b1;
+}
+
+.bien-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.bien-info {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--text-secondary, #666);
+  font-size: 0.95rem;
+}
+
+.bien-surface {
+  margin-left: 0.25rem;
+}
+
+.bien-amounts {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  padding: 0.75rem 0;
+  border-top: 1px dashed var(--border-color, #e0e0e0);
+  border-bottom: 1px dashed var(--border-color, #e0e0e0);
+}
+
+.amount-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.amount-item .label {
+  font-size: 0.875rem;
+  color: var(--text-secondary, #666);
+}
+
+.amount-item .value {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary, #333);
+}
+
+.montant-positif {
+  color: var(--color-success, #4caf50);
+}
+
+.montant-negatif {
+  color: var(--color-danger, #d32f2f);
+}
+
+.icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@media (max-width: 768px) {
+  .bien-card {
+    padding: 1rem;
+  }
+
+  .bien-name {
+    font-size: 1.125rem;
+  }
+
+  .bien-amounts {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/front/src/components/BienForm.vue
+++ b/front/src/components/BienForm.vue
@@ -1,0 +1,570 @@
+<template>
+  <div
+    v-if="bien"
+    class="bien-form"
+    @click="handleBackdropClick"
+    @keypress.enter="saveBien"
+  >
+    <div
+      class="form-card"
+      @click.stop
+    >
+      <h2 class="form-title">
+        {{ bien.IDbien ? "Modifier le bien" : "Nouveau bien" }}
+      </h2>
+
+      <div class="form-group">
+        <label
+          for="bien-name"
+          class="form-label"
+        >Nom du bien</label>
+        <input
+          id="bien-name"
+          v-model="bien.NomBien"
+          type="text"
+          class="form-input"
+          placeholder="Ex: Appartement Lyon 3..."
+        >
+      </div>
+
+      <div class="form-row">
+        <div class="form-group">
+          <label
+            for="bien-city"
+            class="form-label"
+          >Ville</label>
+          <input
+            id="bien-city"
+            v-model="bien.Ville"
+            type="text"
+            class="form-input"
+            placeholder="Ex: Lyon"
+          >
+        </div>
+
+        <div class="form-group">
+          <label
+            for="bien-type"
+            class="form-label"
+          >Type de bien</label>
+          <select
+            id="bien-type"
+            v-model="bien.TypeBien"
+            class="form-select"
+          >
+            <option value="appartement">
+              Appartement
+            </option>
+            <option value="maison">
+              Maison
+            </option>
+            <option value="terrain">
+              Terrain
+            </option>
+            <option value="parking">
+              Parking
+            </option>
+            <option value="local">
+              Local commercial
+            </option>
+          </select>
+        </div>
+      </div>
+
+      <div class="form-row">
+        <div class="form-group">
+          <label
+            for="bien-surface"
+            class="form-label"
+          >Surface (m²)</label>
+          <input
+            id="bien-surface"
+            v-model.number="bien.Surface"
+            type="number"
+            class="form-input"
+            placeholder="0"
+            step="0.01"
+            min="0"
+          >
+        </div>
+
+        <div class="form-group">
+          <label
+            for="bien-usage"
+            class="form-label"
+          >Usage</label>
+          <select
+            id="bien-usage"
+            v-model="bien.Usage"
+            class="form-select"
+          >
+            <option value="principale">
+              Résidence principale
+            </option>
+            <option value="secondaire">
+              Résidence secondaire
+            </option>
+            <option value="locatif">
+              Locatif
+            </option>
+          </select>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label
+          for="bien-date"
+          class="form-label"
+        >Date d'achat</label>
+        <input
+          id="bien-date"
+          v-model="bien.DateAchat"
+          type="date"
+          class="form-input"
+        >
+      </div>
+
+      <fieldset class="form-fieldset">
+        <legend>Prix d'achat</legend>
+
+        <div class="form-row">
+          <div class="form-group">
+            <label
+              for="bien-prix-nu"
+              class="form-label"
+            >Prix du bien nu</label>
+            <input
+              id="bien-prix-nu"
+              v-model.number="bien.PrixBienNu"
+              type="number"
+              class="form-input"
+              placeholder="0.00"
+              step="0.01"
+              min="0"
+              @blur="roundField('PrixBienNu')"
+            >
+          </div>
+
+          <div class="form-group">
+            <label
+              for="bien-frais-notaire"
+              class="form-label"
+            >Frais de notaire</label>
+            <input
+              id="bien-frais-notaire"
+              v-model.number="bien.FraisNotaire"
+              type="number"
+              class="form-input"
+              placeholder="0.00"
+              step="0.01"
+              min="0"
+              @blur="roundField('FraisNotaire')"
+            >
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label
+            for="bien-frais-agence"
+            class="form-label"
+          >Frais d'agence (optionnel)</label>
+          <input
+            id="bien-frais-agence"
+            v-model.number="bien.FraisAgence"
+            type="number"
+            class="form-input"
+            placeholder="0.00"
+            step="0.01"
+            min="0"
+            @blur="roundField('FraisAgence')"
+          >
+        </div>
+
+        <div class="prix-total">
+          <span class="prix-total-label">Total</span>
+          <span class="prix-total-value">{{ formatAmount(prixTotal) }}</span>
+        </div>
+      </fieldset>
+
+      <fieldset class="form-fieldset">
+        <legend>Financement</legend>
+
+        <div class="form-group">
+          <label
+            for="bien-credit"
+            class="form-label"
+          >Crédit associé (optionnel)</label>
+          <select
+            id="bien-credit"
+            v-model="bien.IDcredit"
+            class="form-select"
+          >
+            <option :value="null">
+              Aucun crédit
+            </option>
+            <option
+              v-for="credit in creditList"
+              :key="'credit-' + credit.IDcredit"
+              :value="credit.IDcredit"
+            >
+              {{ credit.NomCredit }}
+            </option>
+          </select>
+        </div>
+
+        <div class="form-group">
+          <label
+            for="bien-apport"
+            class="form-label"
+          >Apport en cash (optionnel)</label>
+          <input
+            id="bien-apport"
+            v-model.number="bien.ApportCash"
+            type="number"
+            class="form-input"
+            placeholder="0.00"
+            step="0.01"
+            min="0"
+            @blur="roundField('ApportCash')"
+          >
+        </div>
+      </fieldset>
+
+      <div class="form-group">
+        <label
+          for="bien-valeur"
+          class="form-label"
+        >Valeur estimée actuelle (optionnel)</label>
+        <input
+          id="bien-valeur"
+          v-model.number="bien.ValeurActuelle"
+          type="number"
+          class="form-input"
+          placeholder="0.00"
+          step="0.01"
+          min="0"
+          @blur="roundField('ValeurActuelle')"
+        >
+      </div>
+
+      <div class="form-actions">
+        <button
+          type="button"
+          class="btn btn-primary"
+          :disabled="!isFormValid"
+          @click="saveBien"
+        >
+          <span class="btn-icon">✓</span>
+          {{ bien.IDbien ? "Modifier" : "Créer" }}
+        </button>
+
+        <button
+          v-if="bien.IDbien"
+          type="button"
+          class="btn btn-danger"
+          @click="removeBien"
+        >
+          <span class="btn-icon">🗑</span>
+          Supprimer
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { ref, computed, onMounted } from 'vue'
+  import { useStore } from 'vuex'
+  import { useRoute, useRouter } from 'vue-router'
+
+  const store = useStore()
+  const route = useRoute()
+  const router = useRouter()
+
+  const bienID = computed(() => Number(route.params.id))
+  const creditList = computed(() => store.state.credit.creditList || [])
+
+  const bien = ref({
+    IDbien: undefined as number | undefined,
+    NomBien: '',
+    Ville: '',
+    TypeBien: 'appartement',
+    Surface: null as number | null,
+    Usage: 'principale',
+    DateAchat: new Date().toISOString().split('T')[0],
+    PrixBienNu: 0,
+    FraisNotaire: 0,
+    FraisAgence: 0,
+    ApportCash: 0,
+    ValeurActuelle: null as number | null,
+    IDcredit: null as number | null
+  })
+
+  const prixTotal = computed(() => {
+    return (
+      (Number(bien.value.PrixBienNu) || 0) +
+      (Number(bien.value.FraisNotaire) || 0) +
+      (Number(bien.value.FraisAgence) || 0)
+    )
+  })
+
+  const isFormValid = computed(() => {
+    return (
+      bien.value.NomBien?.trim() &&
+      bien.value.Ville?.trim() &&
+      bien.value.TypeBien &&
+      bien.value.Usage &&
+      bien.value.DateAchat &&
+      Number(bien.value.PrixBienNu) > 0 &&
+      Number(bien.value.FraisNotaire) >= 0
+    )
+  })
+
+  const roundField = (field: string) => {
+    const value = bien.value[field]
+    if (value !== null && value !== undefined && value !== '') {
+      bien.value[field] = Math.round(Number(value) * 100) / 100
+    }
+  }
+
+  const formatAmount = (amount: number) => {
+    if (amount === undefined || amount === null) return '0,00 €'
+    return new Intl.NumberFormat('fr-FR', {
+      style: 'currency',
+      currency: 'EUR'
+    }).format(amount)
+  }
+
+  const saveBien = () => {
+    if (!isFormValid.value) {
+      alert('Veuillez remplir tous les champs obligatoires')
+      return
+    }
+
+    const bienData = {
+      ...bien.value,
+      DateAchat: new Date(bien.value.DateAchat).toISOString(),
+      Surface: bien.value.Surface || undefined,
+      ValeurActuelle: bien.value.ValeurActuelle || undefined,
+      IDcredit: bien.value.IDcredit || undefined
+    }
+
+    store.dispatch('updateBien', bienData)
+      .then(() => {
+        router.push('/biens')
+      })
+      .catch((error) => {
+        console.error('Error updating bien:', error)
+        alert('Erreur lors de l\'enregistrement du bien')
+      })
+  }
+
+  const removeBien = () => {
+    if (confirm('Êtes-vous sûr de vouloir supprimer ce bien ?')) {
+      store.dispatch('deleteBien', bien.value)
+        .then(() => {
+          router.push('/biens')
+        })
+        .catch((error) => {
+          console.error('Error deleting bien:', error)
+          alert('Erreur lors de la suppression du bien')
+        })
+    }
+  }
+
+  const handleBackdropClick = () => {
+    router.push('/biens')
+  }
+
+  onMounted(() => {
+    if (creditList.value.length === 0) {
+      store.dispatch('fetchCredits')
+    }
+
+    const nameInput = document.querySelector('#bien-name') as HTMLInputElement
+    if (nameInput) nameInput.focus()
+
+    if (bienID.value) {
+      const existing = store.getters.bienFromList(bienID.value)
+      if (existing) {
+        bien.value = { ...existing }
+        bien.value.DateAchat = new Date(existing.DateAchat).toISOString().split('T')[0]
+      }
+    }
+  })
+</script>
+
+<style scoped>
+.bien-form {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+  overflow-y: auto;
+}
+
+.form-card {
+  background: var(--bg-card, #ffffff);
+  border-radius: 16px;
+  padding: 2rem;
+  max-width: 600px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: var(--shadow-xl, 0 20px 60px rgba(0, 0, 0, 0.3));
+}
+
+.form-title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--text-primary, #333);
+  margin: 0 0 1.5rem 0;
+  text-align: center;
+}
+
+.form-group {
+  margin-bottom: 1.25rem;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.form-label {
+  display: block;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: var(--text-primary, #333);
+  margin-bottom: 0.5rem;
+}
+
+.form-input,
+.form-select {
+  width: 100%;
+  padding: 0.75rem;
+  border: 2px solid var(--border-color, #e0e0e0);
+  border-radius: 8px;
+  font-size: 1rem;
+  color: var(--text-primary, #333);
+  background: var(--bg-primary, #ffffff);
+  transition: all 0.3s ease;
+}
+
+.form-input:focus,
+.form-select:focus {
+  outline: none;
+  border-color: var(--primary-color, #667eea);
+  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+}
+
+.form-fieldset {
+  border: 1px solid var(--border-color, #e0e0e0);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.form-fieldset legend {
+  padding: 0 0.5rem;
+  font-weight: 600;
+  color: var(--text-primary, #333);
+}
+
+.prix-total {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 0.5rem;
+  padding-top: 0.75rem;
+  border-top: 1px dashed var(--border-color, #e0e0e0);
+  font-weight: 600;
+}
+
+.prix-total-label {
+  color: var(--text-secondary, #666);
+}
+
+.prix-total-value {
+  color: var(--text-primary, #333);
+  font-size: 1.125rem;
+}
+
+.form-actions {
+  display: flex;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.btn {
+  flex: 1;
+  padding: 1rem 1.5rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: #ffffff;
+}
+
+.btn-primary:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg, 0 10px 20px rgba(0, 0, 0, 0.2));
+}
+
+.btn-danger {
+  background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+  color: #ffffff;
+}
+
+.btn-danger:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg, 0 10px 20px rgba(0, 0, 0, 0.2));
+}
+
+.btn-icon {
+  font-size: 1.125rem;
+}
+
+@media (max-width: 768px) {
+  .form-card {
+    padding: 1.5rem;
+    max-height: 95vh;
+  }
+
+  .form-title {
+    font-size: 1.5rem;
+  }
+
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+
+  .form-actions {
+    flex-direction: column;
+  }
+}
+</style>

--- a/front/src/components/BienList.vue
+++ b/front/src/components/BienList.vue
@@ -1,0 +1,116 @@
+<template>
+  <div class="bien-list">
+    <div
+      v-if="isLoadingBiens && biensList.length === 0"
+      class="loading-indicator"
+    >
+      <font-awesome-icon
+        icon="spinner"
+        spin
+        class="loading-icon"
+      />
+      <span>Chargement des biens...</span>
+    </div>
+
+    <div
+      v-else-if="biensList.length === 0"
+      class="empty-state"
+    >
+      <font-awesome-icon
+        icon="home"
+        class="empty-icon"
+      />
+      <p class="empty-message">
+        Aucun bien enregistré
+      </p>
+      <p class="empty-sub">
+        Ajoutez votre premier bien immobilier en cliquant sur le bouton +
+      </p>
+    </div>
+
+    <div
+      v-else
+      class="biens-container"
+    >
+      <BienCard
+        v-for="bien in biensList"
+        :key="bien.IDbien"
+        :bien="bien"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+  import { computed } from 'vue'
+  import { useStore } from 'vuex'
+  import BienCard from './BienCard.vue'
+
+  const store = useStore()
+
+  const biensList = computed(() => store.state.bien.bienList || [])
+  const isLoadingBiens = computed(() => store.state.bien.isLoadingBiens)
+</script>
+
+<style scoped>
+.bien-list {
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.loading-indicator {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1rem;
+  color: var(--text-secondary, #666);
+  gap: 1rem;
+}
+
+.loading-icon {
+  font-size: 2rem;
+  color: var(--primary-color, #1976d2);
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1rem;
+  text-align: center;
+}
+
+.empty-icon {
+  font-size: 4rem;
+  color: var(--text-light, #ccc);
+  margin-bottom: 1rem;
+}
+
+.empty-message {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-primary, #333);
+  margin: 0 0 0.5rem 0;
+}
+
+.empty-sub {
+  font-size: 1rem;
+  color: var(--text-secondary, #666);
+  margin: 0;
+}
+
+.biens-container {
+  display: flex;
+  flex-direction: column;
+}
+
+@media (max-width: 768px) {
+  .bien-list {
+    padding: 0.5rem;
+  }
+}
+</style>

--- a/front/src/components/NavBar.vue
+++ b/front/src/components/NavBar.vue
@@ -274,41 +274,41 @@
 
 .btn-bien {
   color: #fff;
-  background-color: #20c997;
-  border-color: #20c997;
+  background-color: #e83e8c;
+  border-color: #e83e8c;
 }
 
 .btn-bien:hover {
   color: #fff;
-  background-color: #1ba884;
-  border-color: #178d6f;
+  background-color: #d6336c;
+  border-color: #c42a60;
 }
 
 .btn-bien:focus,
 .btn-bien.focus {
   color: #fff;
-  background-color: #1ba884;
-  border-color: #178d6f;
-  box-shadow: 0 0 0 0.2rem rgba(32, 201, 151, 0.5);
+  background-color: #d6336c;
+  border-color: #c42a60;
+  box-shadow: 0 0 0 0.2rem rgba(232, 62, 140, 0.5);
 }
 
 .btn-bien.disabled,
 .btn-bien:disabled {
   color: #fff;
-  background-color: #20c997;
-  border-color: #20c997;
+  background-color: #e83e8c;
+  border-color: #e83e8c;
 }
 
 .btn-bien:not(:disabled):not(.disabled):active,
 .btn-bien:not(:disabled):not(.disabled).active {
   color: #fff;
-  background-color: #178d6f;
-  border-color: #156b55;
+  background-color: #c42a60;
+  border-color: #ad2354;
 }
 
 .btn-bien:not(:disabled):not(.disabled):active:focus,
 .btn-bien:not(:disabled):not(.disabled).active:focus {
-  box-shadow: 0 0 0 0.2rem rgba(32, 201, 151, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(232, 62, 140, 0.5);
 }
 
 .btn-credit {

--- a/front/src/components/NavBar.vue
+++ b/front/src/components/NavBar.vue
@@ -19,7 +19,7 @@
     </button>
     <button
       class="btn btn-primary new-operation-button"
-      :disabled="disabled.valueOf() && route.name !== 'Opérations récurrentes' && route.name !== 'Crédits'"
+      :disabled="disabled.valueOf() && route.name !== 'Opérations récurrentes' && route.name !== 'Crédits' && route.name !== 'Biens'"
       @click="addOperation"
     >
       <font-awesome-icon icon="plus" />
@@ -44,6 +44,13 @@
       @click="getCredits"
     >
       <font-awesome-icon icon="credit-card" />
+    </button>
+    <button
+      class="btn btn-bien bien-button"
+      :disabled="route.name === 'Login'"
+      @click="getBiens"
+    >
+      <font-awesome-icon icon="home" />
     </button>
     <button
       class="btn btn-danger params-button"
@@ -79,6 +86,8 @@
       router.push('/newRecurrOperation')
     } else if (route.name === 'Crédits') {
       router.push('/newCredit')
+    } else if (route.name === 'Biens') {
+      router.push('/newBien')
     } else {
       router.push('/newOperation')
     }
@@ -102,6 +111,11 @@
   const getCredits = () => {
     store.dispatch('toggleAccountList', false)
     router.push('/credits')
+  }
+
+  const getBiens = () => {
+    store.dispatch('toggleAccountList', false)
+    router.push('/biens')
   }
 
   const changeParams = () => {
@@ -256,6 +270,45 @@
 .btn-success:not(:disabled):not(.disabled):active:focus,
 .btn-success:not(:disabled):not(.disabled).active:focus {
   box-shadow: 0 0 0 0.2rem rgba(72, 180, 97, 0.5);
+}
+
+.btn-bien {
+  color: #fff;
+  background-color: #20c997;
+  border-color: #20c997;
+}
+
+.btn-bien:hover {
+  color: #fff;
+  background-color: #1ba884;
+  border-color: #178d6f;
+}
+
+.btn-bien:focus,
+.btn-bien.focus {
+  color: #fff;
+  background-color: #1ba884;
+  border-color: #178d6f;
+  box-shadow: 0 0 0 0.2rem rgba(32, 201, 151, 0.5);
+}
+
+.btn-bien.disabled,
+.btn-bien:disabled {
+  color: #fff;
+  background-color: #20c997;
+  border-color: #20c997;
+}
+
+.btn-bien:not(:disabled):not(.disabled):active,
+.btn-bien:not(:disabled):not(.disabled).active {
+  color: #fff;
+  background-color: #178d6f;
+  border-color: #156b55;
+}
+
+.btn-bien:not(:disabled):not(.disabled):active:focus,
+.btn-bien:not(:disabled):not(.disabled).active:focus {
+  box-shadow: 0 0 0 0.2rem rgba(32, 201, 151, 0.5);
 }
 
 .btn-credit {
@@ -499,6 +552,14 @@
         margin-right: 0;
       }
       &.credit-button {
+        border-top-left-radius: 0px;
+        border-bottom-left-radius: 0px;
+        border-top-right-radius: 0px;
+        border-bottom-right-radius: 0px;
+        margin-left: 0;
+        margin-right: 0;
+      }
+      &.bien-button {
         border-top-left-radius: 0px;
         border-bottom-left-radius: 0px;
         margin-left: 0;

--- a/front/src/plugins/fontawesome.ts
+++ b/front/src/plugins/fontawesome.ts
@@ -32,7 +32,13 @@ import {
   faSpinner,
   faInfoCircle,
   faExclamationCircle,
-  faCheckCircle
+  faCheckCircle,
+  faHome,
+  faMapMarkerAlt,
+  faCalendar,
+  faWallet,
+  faBuilding,
+  faPercent
 } from '@fortawesome/free-solid-svg-icons'
 
 const FontAwesome = {
@@ -70,7 +76,13 @@ const FontAwesome = {
       faSpinner,
       faInfoCircle,
       faExclamationCircle,
-      faCheckCircle
+      faCheckCircle,
+      faHome,
+      faMapMarkerAlt,
+      faCalendar,
+      faWallet,
+      faBuilding,
+      faPercent
     } as any)
   }
 }

--- a/front/src/router.ts
+++ b/front/src/router.ts
@@ -8,6 +8,7 @@ const EditUser = () => import(/* webpackChunkName: "edituser" */ './views/EditUs
 const OperationsRecurrentes = () => import(/* webpackChunkName: "operecur" */ './views/OperationsRecurrentes.vue')
 const Amortissement = () => import(/* webpackChunkName: "operecur" */ './views/Amortissement.vue')
 const Credits = () => import(/* webpackChunkName: "credits" */ './views/Credits.vue')
+const Biens = () => import(/* webpackChunkName: "biens" */ './views/Biens.vue')
 const RouteOverTheContent = () => import(/* webpackChunkName: "othercontent" */ './views/RouteOverTheContent.vue')
 
 export default createRouter({
@@ -101,6 +102,28 @@ export default createRouter({
       component: RouteOverTheContent,
       props: {
         componentName: 'credit-form'
+      }
+    }]
+  }, {
+    path: '/biens',
+    name: 'Biens',
+    component: Biens,
+    meta: {
+      disabledTotalHeader: true
+    },
+    children: [{
+      path: '/newBien',
+      name: 'Nouveau bien',
+      component: RouteOverTheContent,
+      props: {
+        componentName: 'bien-form'
+      }
+    }, {
+      path: '/editBien/:id',
+      name: 'Edition bien',
+      component: RouteOverTheContent,
+      props: {
+        componentName: 'bien-form'
       }
     }]
   }, {

--- a/front/src/services/bien.ts
+++ b/front/src/services/bien.ts
@@ -1,0 +1,57 @@
+import axios from 'axios'
+
+export const fetchBiens = (userToken, APIURL) => {
+  return axios
+    .get(APIURL + '/api/biens', {
+      headers: {
+        Authorization: 'Bearer ' + userToken
+      }
+    })
+    .then((response) => {
+      return response.data
+    })
+}
+
+export const fetchBienById = (IDbien, userToken, APIURL) => {
+  return axios
+    .get(APIURL + '/api/biens/' + IDbien, {
+      headers: {
+        Authorization: 'Bearer ' + userToken
+      }
+    })
+    .then((response) => {
+      return response.data
+    })
+}
+
+export const updateBien = (bien, userToken, APIURL) => {
+  if (bien.IDbien) {
+    return axios.put(
+      APIURL + '/api/biens/' + bien.IDbien,
+      { ...bien, IDbien: undefined },
+      {
+        headers: {
+          Authorization: 'Bearer ' + userToken
+        }
+      }
+    )
+  } else {
+    return axios.post(
+      APIURL + '/api/biens/',
+      bien,
+      {
+        headers: {
+          Authorization: 'Bearer ' + userToken
+        }
+      }
+    )
+  }
+}
+
+export const deleteBien = (IDbien, userToken, APIURL) => {
+  return axios.delete(APIURL + '/api/biens/' + IDbien, {
+    headers: {
+      Authorization: 'Bearer ' + userToken
+    }
+  })
+}

--- a/front/src/store/bien.ts
+++ b/front/src/store/bien.ts
@@ -1,0 +1,90 @@
+import {
+  fetchBiens,
+  fetchBienById,
+  updateBien,
+  deleteBien
+} from '@/services/bien'
+
+export default {
+  state: {
+    bienList: [],
+    activeBien: null,
+    isLoadingBiens: false
+  },
+
+  getters: {
+    bienFromList: (state) => (bienID) => {
+      return state.bienList.find((bien) => bien.IDbien === bienID)
+    }
+  },
+
+  mutations: {
+    setBienList (state, biens) {
+      state.bienList = biens
+    },
+    setActiveBien (state, bien) {
+      state.activeBien = bien
+    },
+    setIsLoadingBiens (state, isLoading) {
+      state.isLoadingBiens = isLoading
+    }
+  },
+
+  actions: {
+    async fetchBiens ({ rootState, commit }) {
+      commit('setIsLoadingBiens', true)
+      try {
+        const biens = await fetchBiens(
+          rootState.user.token,
+          window.env.VITE_API_URL
+        )
+        commit('setBienList', Array.isArray(biens) ? biens : [])
+      } catch (error) {
+        console.error('Error fetching biens:', error)
+      } finally {
+        commit('setIsLoadingBiens', false)
+      }
+    },
+
+    async updateBien ({ dispatch, rootState }, bien) {
+      try {
+        await updateBien(
+          bien,
+          rootState.user.token,
+          window.env.VITE_API_URL
+        )
+        dispatch('fetchBiens')
+      } catch (error) {
+        console.error('Error updating bien:', error)
+        throw error
+      }
+    },
+
+    async deleteBien ({ dispatch, rootState }, bien) {
+      try {
+        await deleteBien(
+          bien.IDbien,
+          rootState.user.token,
+          window.env.VITE_API_URL
+        )
+        dispatch('fetchBiens')
+      } catch (error) {
+        console.error('Error deleting bien:', error)
+        throw error
+      }
+    },
+
+    async fetchBienDetails ({ rootState, commit }, IDbien) {
+      try {
+        const bien = await fetchBienById(
+          IDbien,
+          rootState.user.token,
+          window.env.VITE_API_URL
+        )
+        commit('setActiveBien', bien)
+      } catch (error) {
+        console.error('Error fetching bien details:', error)
+      }
+    }
+  }
+}

--- a/front/src/store/index.ts
+++ b/front/src/store/index.ts
@@ -7,6 +7,7 @@ import Dispay from './display'
 import Stats from './stats'
 import Compte from './compte'
 import Credit from './credit'
+import Bien from './bien'
 
 export default createStore({
   modules: {
@@ -16,6 +17,7 @@ export default createStore({
     display: Dispay,
     stats: Stats,
     compte: Compte,
-    credit: Credit
+    credit: Credit,
+    bien: Bien
   }
 })

--- a/front/src/views/Biens.vue
+++ b/front/src/views/Biens.vue
@@ -1,0 +1,133 @@
+<template>
+  <div class="biens-view">
+    <router-view />
+
+    <div
+      v-if="biensList.length > 0"
+      class="summary-cards"
+    >
+      <div class="summary-card">
+        <span class="summary-label">Nombre de biens</span>
+        <span class="summary-value">{{ biensList.length }}</span>
+      </div>
+      <div class="summary-card">
+        <span class="summary-label">Investissement total</span>
+        <span class="summary-value">{{ formatAmount(totalInvestissement) }}</span>
+      </div>
+      <div class="summary-card">
+        <span class="summary-label">Valeur estimée</span>
+        <span class="summary-value">{{ formatAmount(totalValeurActuelle) }}</span>
+      </div>
+    </div>
+
+    <BienList />
+  </div>
+</template>
+
+<script setup>
+  import { computed, onMounted } from 'vue'
+  import { useStore } from 'vuex'
+  import BienList from '@/components/BienList.vue'
+
+  const store = useStore()
+
+  const biensList = computed(() => store.state.bien.bienList || [])
+
+  const totalInvestissement = computed(() => {
+    return biensList.value.reduce((sum, bien) => {
+      return (
+        sum +
+        (bien.PrixBienNu || 0) +
+        (bien.FraisNotaire || 0) +
+        (bien.FraisAgence || 0)
+      )
+    }, 0)
+  })
+
+  const totalValeurActuelle = computed(() => {
+    return biensList.value.reduce((sum, bien) => {
+      const value =
+        bien.ValeurActuelle ||
+        (bien.PrixBienNu || 0) +
+        (bien.FraisNotaire || 0) +
+        (bien.FraisAgence || 0)
+      return sum + value
+    }, 0)
+  })
+
+  const formatAmount = (amount) => {
+    if (amount === undefined || amount === null) return '0,00 €'
+    return new Intl.NumberFormat('fr-FR', {
+      style: 'currency',
+      currency: 'EUR'
+    }).format(amount)
+  }
+
+  onMounted(() => {
+    store.dispatch('fetchBiens')
+    store.dispatch('fetchCredits')
+    store.commit('setActiveAccount', { NomCompte: 'Mes biens' })
+  })
+</script>
+
+<style lang="scss" scoped>
+.biens-view {
+  min-height: 100vh;
+  background: var(--bg-primary, #f5f5f5);
+  padding-bottom: 5rem;
+}
+
+.summary-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  max-width: 800px;
+  margin: 1rem auto;
+  padding: 0 1rem;
+}
+
+.summary-card {
+  background: var(--primary-gradient, linear-gradient(135deg, #667eea 0%, #764ba2 100%));
+  border-radius: 12px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  box-shadow: var(--shadow-md, 0 4px 6px rgba(0, 0, 0, 0.1));
+}
+
+.summary-card:nth-child(2) {
+  background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
+}
+
+.summary-card:nth-child(3) {
+  background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
+}
+
+.summary-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.summary-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+@media (max-width: 768px) {
+  .summary-cards {
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+  }
+
+  .summary-card {
+    padding: 1rem;
+  }
+
+  .summary-value {
+    font-size: 1.25rem;
+  }
+}
+</style>

--- a/front/src/views/RouteOverTheContent.vue
+++ b/front/src/views/RouteOverTheContent.vue
@@ -16,13 +16,15 @@
   import Search from '@/components/Search.vue'
   import TransfertForm from '@/components/TransfertForm.vue'
   import CreditForm from '@/components/CreditForm.vue'
+  import BienForm from '@/components/BienForm.vue'
 
   const components = {
     'operation-form': OperationForm,
     'operation-recurrente-form': OperationRecurrenteForm,
     search: Search,
     'transfert-form': TransfertForm,
-    'credit-form': CreditForm
+    'credit-form': CreditForm,
+    'bien-form': BienForm
   }
 
   const props = defineProps({
@@ -41,6 +43,8 @@
       router.push('/recurrOperation')
     } else if (props.componentName === 'credit-form') {
       router.push('/credits')
+    } else if (props.componentName === 'bien-form') {
+      router.push('/biens')
     } else {
       router.push('/')
     }

--- a/mockups/option-3-bottom-tabs-fab.html
+++ b/mockups/option-3-bottom-tabs-fab.html
@@ -1,0 +1,616 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mockup — Option 3 : Bottom tabs + FAB</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+      min-height: 100vh;
+      padding: 32px 16px;
+    }
+
+    h1 {
+      text-align: center;
+      color: #2d3748;
+      margin-bottom: 8px;
+      font-size: 28px;
+    }
+    .subtitle {
+      text-align: center;
+      color: #718096;
+      margin-bottom: 32px;
+      font-size: 15px;
+    }
+
+    .phones {
+      display: flex;
+      gap: 32px;
+      justify-content: center;
+      flex-wrap: wrap;
+      align-items: flex-start;
+    }
+
+    .phone-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 12px;
+    }
+    .phone-label {
+      background: #2d3748;
+      color: white;
+      padding: 6px 16px;
+      border-radius: 20px;
+      font-size: 13px;
+      font-weight: 600;
+    }
+
+    .phone {
+      width: 360px;
+      height: 720px;
+      background: #f8fafc;
+      border-radius: 40px;
+      box-shadow: 0 20px 60px rgba(0,0,0,0.2);
+      border: 8px solid #1a202c;
+      position: relative;
+      overflow: hidden;
+    }
+
+    /* Status bar */
+    .status-bar {
+      height: 32px;
+      background: #f8fafc;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0 24px;
+      font-size: 12px;
+      font-weight: 600;
+      color: #2d3748;
+    }
+    .status-bar .right { display: flex; gap: 6px; }
+
+    /* Header */
+    .header {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      padding: 16px 20px;
+      color: white;
+    }
+    .header-top {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 8px;
+    }
+    .header-title {
+      font-size: 14px;
+      opacity: 0.9;
+    }
+    .header-account {
+      font-size: 20px;
+      font-weight: 700;
+      margin-bottom: 4px;
+    }
+    .header-balance {
+      font-size: 28px;
+      font-weight: 700;
+    }
+    .header-meta {
+      font-size: 12px;
+      opacity: 0.85;
+      margin-top: 4px;
+    }
+
+    /* Content area */
+    .content {
+      height: calc(100% - 32px - 130px - 80px);
+      overflow-y: auto;
+      padding: 12px;
+    }
+
+    /* Operation row */
+    .op-row {
+      display: flex;
+      align-items: center;
+      background: white;
+      border-radius: 12px;
+      padding: 12px 16px;
+      margin-bottom: 8px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.04);
+    }
+    .op-icon {
+      width: 36px;
+      height: 36px;
+      border-radius: 50%;
+      background: #edf2f7;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #4a5568;
+      margin-right: 12px;
+      font-size: 14px;
+    }
+    .op-body { flex: 1; }
+    .op-name { font-size: 14px; font-weight: 600; color: #2d3748; }
+    .op-cat { font-size: 12px; color: #a0aec0; margin-top: 2px; }
+    .op-amount {
+      font-size: 14px;
+      font-weight: 700;
+    }
+    .pos { color: #38a169; }
+    .neg { color: #e53e3e; }
+
+    /* Patrimoine landing */
+    .patrimoine-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+      padding: 8px;
+    }
+    .patrimoine-card {
+      background: white;
+      border-radius: 16px;
+      padding: 20px 16px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 8px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+      cursor: pointer;
+      transition: all 0.2s;
+      position: relative;
+      overflow: hidden;
+    }
+    .patrimoine-card:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 8px 16px rgba(0,0,0,0.1);
+    }
+    .patrimoine-icon {
+      width: 56px;
+      height: 56px;
+      border-radius: 16px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: white;
+      font-size: 22px;
+      margin-bottom: 4px;
+    }
+    .pi-credit { background: linear-gradient(135deg, #6f42c1 0%, #4e2a8e 100%); }
+    .pi-bien { background: linear-gradient(135deg, #e83e8c 0%, #c42a60 100%); }
+    .pi-amort { background: linear-gradient(135deg, #28a745 0%, #1e7e34 100%); }
+    .pi-recur { background: linear-gradient(135deg, #17a2b8 0%, #117a8b 100%); }
+
+    .patrimoine-label {
+      font-size: 14px;
+      font-weight: 600;
+      color: #2d3748;
+    }
+    .patrimoine-count {
+      font-size: 12px;
+      color: #a0aec0;
+    }
+
+    /* Bottom tab bar */
+    .tab-bar {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 80px;
+      background: rgba(255, 255, 255, 0.95);
+      backdrop-filter: blur(20px);
+      border-top: 1px solid #e2e8f0;
+      display: flex;
+      justify-content: space-around;
+      align-items: flex-start;
+      padding-top: 10px;
+      box-shadow: 0 -4px 20px rgba(0,0,0,0.05);
+    }
+    .tab {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      padding: 6px 14px;
+      cursor: pointer;
+      color: #a0aec0;
+      transition: color 0.2s;
+      flex: 1;
+      max-width: 80px;
+    }
+    .tab i { font-size: 22px; }
+    .tab span { font-size: 11px; font-weight: 600; }
+    .tab.active { color: #667eea; }
+    .tab.active i {
+      transform: scale(1.1);
+    }
+
+    /* FAB */
+    .fab-container {
+      position: absolute;
+      right: 20px;
+      bottom: 96px;
+      display: flex;
+      flex-direction: column-reverse;
+      align-items: center;
+      gap: 12px;
+      z-index: 100;
+    }
+    .fab {
+      width: 60px;
+      height: 60px;
+      border-radius: 50%;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: 0 8px 20px rgba(102, 126, 234, 0.4);
+      cursor: pointer;
+      transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+      font-size: 22px;
+      border: none;
+    }
+    .fab:hover { transform: scale(1.05); }
+    .fab.expanded { transform: rotate(45deg); }
+
+    .mini-fab {
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: white;
+      font-size: 16px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+      position: relative;
+      animation: popIn 0.25s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
+    }
+    .mini-fab:nth-child(1) { animation-delay: 0.05s; background: linear-gradient(135deg, #ffc107, #e0a800); color: #212529; }
+    .mini-fab:nth-child(2) { animation-delay: 0.1s; background: linear-gradient(135deg, #007bff, #0056b3); }
+    .mini-fab:nth-child(3) { animation-delay: 0.15s; background: linear-gradient(135deg, #17a2b8, #117a8b); }
+
+    .mini-fab .label {
+      position: absolute;
+      right: 60px;
+      background: #2d3748;
+      color: white;
+      padding: 6px 12px;
+      border-radius: 8px;
+      font-size: 12px;
+      white-space: nowrap;
+      font-weight: 600;
+    }
+
+    @keyframes popIn {
+      from { opacity: 0; transform: scale(0.5) translateY(20px); }
+      to { opacity: 1; transform: scale(1) translateY(0); }
+    }
+
+    /* Section headers */
+    .section-title {
+      font-size: 13px;
+      font-weight: 700;
+      color: #4a5568;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      padding: 12px 16px 8px;
+    }
+
+    /* Backdrop for expanded FAB */
+    .fab-backdrop {
+      position: absolute;
+      inset: 0;
+      background: rgba(0,0,0,0.3);
+      backdrop-filter: blur(2px);
+      z-index: 50;
+    }
+
+    /* Description below */
+    .description {
+      max-width: 1100px;
+      margin: 48px auto 0;
+      background: white;
+      padding: 28px 32px;
+      border-radius: 16px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+    }
+    .description h2 {
+      color: #2d3748;
+      margin-bottom: 16px;
+      font-size: 20px;
+    }
+    .description ul { padding-left: 24px; line-height: 1.9; color: #4a5568; }
+    .description strong { color: #2d3748; }
+  </style>
+</head>
+<body>
+  <h1>Option 3 — Bottom tabs + Floating Action Button</h1>
+  <p class="subtitle">3 écrans : navigation par onglets · FAB déployé · Vue Patrimoine</p>
+
+  <div class="phones">
+
+    <!-- ===== PHONE 1 : Home avec tab bar ===== -->
+    <div class="phone-wrapper">
+      <div class="phone-label">1. Accueil — onglet Comptes</div>
+      <div class="phone">
+        <div class="status-bar">
+          <span>9:41</span>
+          <div class="right">
+            <i class="fas fa-signal"></i>
+            <i class="fas fa-wifi"></i>
+            <i class="fas fa-battery-three-quarters"></i>
+          </div>
+        </div>
+
+        <div class="header">
+          <div class="header-top">
+            <span class="header-title">Compte courant</span>
+            <i class="fas fa-eye"></i>
+          </div>
+          <div class="header-balance">2 458,32 €</div>
+          <div class="header-meta">À pointer : -120,50 €</div>
+        </div>
+
+        <div class="content">
+          <div class="op-row">
+            <div class="op-icon"><i class="fas fa-shopping-cart"></i></div>
+            <div class="op-body">
+              <div class="op-name">Carrefour</div>
+              <div class="op-cat">Courses · 02/05</div>
+            </div>
+            <div class="op-amount neg">-58,40 €</div>
+          </div>
+          <div class="op-row">
+            <div class="op-icon"><i class="fas fa-money-bill-wave"></i></div>
+            <div class="op-body">
+              <div class="op-name">Salaire avril</div>
+              <div class="op-cat">Revenus · 30/04</div>
+            </div>
+            <div class="op-amount pos">+2 800,00 €</div>
+          </div>
+          <div class="op-row">
+            <div class="op-icon"><i class="fas fa-bolt"></i></div>
+            <div class="op-body">
+              <div class="op-name">EDF</div>
+              <div class="op-cat">Énergie · 28/04</div>
+            </div>
+            <div class="op-amount neg">-89,12 €</div>
+          </div>
+          <div class="op-row">
+            <div class="op-icon"><i class="fas fa-utensils"></i></div>
+            <div class="op-body">
+              <div class="op-name">Restaurant Le Bistrot</div>
+              <div class="op-cat">Restaurants · 27/04</div>
+            </div>
+            <div class="op-amount neg">-42,00 €</div>
+          </div>
+          <div class="op-row">
+            <div class="op-icon"><i class="fas fa-gas-pump"></i></div>
+            <div class="op-body">
+              <div class="op-name">Total</div>
+              <div class="op-cat">Carburant · 25/04</div>
+            </div>
+            <div class="op-amount neg">-72,80 €</div>
+          </div>
+        </div>
+
+        <!-- FAB -->
+        <div class="fab-container">
+          <button class="fab"><i class="fas fa-plus"></i></button>
+        </div>
+
+        <!-- Tab bar -->
+        <div class="tab-bar">
+          <div class="tab active">
+            <i class="fas fa-wallet"></i>
+            <span>Comptes</span>
+          </div>
+          <div class="tab">
+            <i class="fas fa-building"></i>
+            <span>Patrimoine</span>
+          </div>
+          <div class="tab">
+            <i class="fas fa-chart-pie"></i>
+            <span>Stats</span>
+          </div>
+          <div class="tab">
+            <i class="fas fa-cog"></i>
+            <span>Réglages</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== PHONE 2 : FAB déployé ===== -->
+    <div class="phone-wrapper">
+      <div class="phone-label">2. FAB déployé — actions rapides</div>
+      <div class="phone">
+        <div class="status-bar">
+          <span>9:41</span>
+          <div class="right">
+            <i class="fas fa-signal"></i>
+            <i class="fas fa-wifi"></i>
+            <i class="fas fa-battery-three-quarters"></i>
+          </div>
+        </div>
+
+        <div class="header">
+          <div class="header-top">
+            <span class="header-title">Compte courant</span>
+            <i class="fas fa-eye"></i>
+          </div>
+          <div class="header-balance">2 458,32 €</div>
+          <div class="header-meta">À pointer : -120,50 €</div>
+        </div>
+
+        <div class="content">
+          <div class="op-row">
+            <div class="op-icon"><i class="fas fa-shopping-cart"></i></div>
+            <div class="op-body">
+              <div class="op-name">Carrefour</div>
+              <div class="op-cat">Courses · 02/05</div>
+            </div>
+            <div class="op-amount neg">-58,40 €</div>
+          </div>
+          <div class="op-row">
+            <div class="op-icon"><i class="fas fa-money-bill-wave"></i></div>
+            <div class="op-body">
+              <div class="op-name">Salaire avril</div>
+              <div class="op-cat">Revenus · 30/04</div>
+            </div>
+            <div class="op-amount pos">+2 800,00 €</div>
+          </div>
+        </div>
+
+        <div class="fab-backdrop"></div>
+
+        <!-- FAB expanded -->
+        <div class="fab-container">
+          <button class="fab expanded"><i class="fas fa-plus"></i></button>
+          <div class="mini-fab">
+            <i class="fas fa-exchange-alt"></i>
+            <span class="label">Virement</span>
+          </div>
+          <div class="mini-fab">
+            <i class="fas fa-pen"></i>
+            <span class="label">Nouvelle opération</span>
+          </div>
+          <div class="mini-fab">
+            <i class="fas fa-search"></i>
+            <span class="label">Rechercher</span>
+          </div>
+        </div>
+
+        <!-- Tab bar -->
+        <div class="tab-bar">
+          <div class="tab active">
+            <i class="fas fa-wallet"></i>
+            <span>Comptes</span>
+          </div>
+          <div class="tab">
+            <i class="fas fa-building"></i>
+            <span>Patrimoine</span>
+          </div>
+          <div class="tab">
+            <i class="fas fa-chart-pie"></i>
+            <span>Stats</span>
+          </div>
+          <div class="tab">
+            <i class="fas fa-cog"></i>
+            <span>Réglages</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== PHONE 3 : Patrimoine ===== -->
+    <div class="phone-wrapper">
+      <div class="phone-label">3. Onglet Patrimoine — hub</div>
+      <div class="phone">
+        <div class="status-bar">
+          <span>9:41</span>
+          <div class="right">
+            <i class="fas fa-signal"></i>
+            <i class="fas fa-wifi"></i>
+            <i class="fas fa-battery-three-quarters"></i>
+          </div>
+        </div>
+
+        <div class="header">
+          <div class="header-top">
+            <span class="header-title">Patrimoine total</span>
+            <i class="fas fa-eye"></i>
+          </div>
+          <div class="header-balance">412 580 €</div>
+          <div class="header-meta">+18 200 € de plus-value latente</div>
+        </div>
+
+        <div class="content" style="padding: 4px;">
+          <div class="section-title">Mes outils</div>
+          <div class="patrimoine-grid">
+            <div class="patrimoine-card">
+              <div class="patrimoine-icon pi-bien">
+                <i class="fas fa-home"></i>
+              </div>
+              <div class="patrimoine-label">Biens</div>
+              <div class="patrimoine-count">2 biens · 385 k€</div>
+            </div>
+            <div class="patrimoine-card">
+              <div class="patrimoine-icon pi-credit">
+                <i class="fas fa-credit-card"></i>
+              </div>
+              <div class="patrimoine-label">Crédits</div>
+              <div class="patrimoine-count">3 actifs · -187 k€</div>
+            </div>
+            <div class="patrimoine-card">
+              <div class="patrimoine-icon pi-recur">
+                <i class="fas fa-retweet"></i>
+              </div>
+              <div class="patrimoine-label">Récurrentes</div>
+              <div class="patrimoine-count">12 opérations</div>
+            </div>
+            <div class="patrimoine-card">
+              <div class="patrimoine-icon pi-amort">
+                <i class="fas fa-history"></i>
+              </div>
+              <div class="patrimoine-label">Amortissement</div>
+              <div class="patrimoine-count">Suivi 2026</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- FAB - contextuel pour Patrimoine -->
+        <div class="fab-container">
+          <button class="fab"><i class="fas fa-plus"></i></button>
+        </div>
+
+        <!-- Tab bar -->
+        <div class="tab-bar">
+          <div class="tab">
+            <i class="fas fa-wallet"></i>
+            <span>Comptes</span>
+          </div>
+          <div class="tab active">
+            <i class="fas fa-building"></i>
+            <span>Patrimoine</span>
+          </div>
+          <div class="tab">
+            <i class="fas fa-chart-pie"></i>
+            <span>Stats</span>
+          </div>
+          <div class="tab">
+            <i class="fas fa-cog"></i>
+            <span>Réglages</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="description">
+    <h2>Ce que change ce design</h2>
+    <ul>
+      <li><strong>4 onglets de navigation</strong> en bas, fixes : <em>Comptes</em>, <em>Patrimoine</em>, <em>Stats</em>, <em>Réglages</em>. Plus on ajoute de fonctionnalités, plus on les regroupe sous un onglet — la navbar n'enfle plus jamais.</li>
+      <li><strong>Un FAB rond en bas à droite</strong> pour les actions de création. Il est <em>contextuel</em> : sur Comptes il propose Opération / Virement / Recherche ; sur Patrimoine il proposera Bien / Crédit / Récurrente.</li>
+      <li><strong>Onglet Patrimoine = hub visuel</strong> avec une grille de cartes (Biens, Crédits, Récurrentes, Amortissement). Chaque carte affiche un compteur ou un total. C'est plus découvrable qu'une liste de boutons.</li>
+      <li><strong>Le hamburger disparaît</strong> sur mobile : la liste des comptes peut basculer en horizontal scrollable au-dessus des opérations, ou rester en panneau swipeable mais sans bouton dédié (geste seul).</li>
+    </ul>
+    <h2 style="margin-top: 24px;">Effort d'implémentation</h2>
+    <ul>
+      <li>Refonte de <code>NavBar.vue</code> (tab bar) + nouveau composant <code>FabMenu.vue</code> (speed-dial)</li>
+      <li>Nouvelle vue <code>Patrimoine.vue</code> qui sert de hub + ajustement des routes (les 4 vues actuelles deviennent enfants)</li>
+      <li>Adaptation du layout dans <code>App.vue</code> pour le panneau gauche</li>
+      <li>Pas de changement backend</li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/mockups/option-3-desktop-ipad.html
+++ b/mockups/option-3-desktop-ipad.html
@@ -1,0 +1,837 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mockup — Option 3 (Desktop / iPad paysage)</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+      min-height: 100vh;
+      padding: 32px 16px;
+    }
+
+    h1 { text-align: center; color: #2d3748; margin-bottom: 8px; font-size: 28px; }
+    .subtitle { text-align: center; color: #718096; margin-bottom: 32px; font-size: 15px; }
+
+    .screens { display: flex; flex-direction: column; align-items: center; gap: 40px; }
+
+    .screen-wrapper { display: flex; flex-direction: column; align-items: center; gap: 14px; width: 100%; }
+    .screen-label {
+      background: #2d3748; color: white; padding: 6px 18px;
+      border-radius: 20px; font-size: 13px; font-weight: 600;
+    }
+
+    /* iPad landscape frame */
+    .ipad {
+      width: 1180px;
+      height: 820px;
+      background: #f8fafc;
+      border-radius: 24px;
+      box-shadow: 0 30px 80px rgba(0,0,0,0.25);
+      border: 14px solid #1a202c;
+      position: relative;
+      overflow: hidden;
+      max-width: 100%;
+    }
+
+    .layout {
+      display: flex;
+      height: 100%;
+    }
+
+    /* === LEFT RAIL (vertical nav) === */
+    .nav-rail {
+      width: 84px;
+      background: linear-gradient(180deg, #2d3748 0%, #1a202c 100%);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 20px 0;
+      gap: 8px;
+    }
+    .nav-rail .logo {
+      width: 44px; height: 44px;
+      border-radius: 12px;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      display: flex; align-items: center; justify-content: center;
+      color: white; font-weight: 800; font-size: 16px;
+      margin-bottom: 16px;
+      box-shadow: 0 4px 12px rgba(102,126,234,0.4);
+    }
+    .rail-tab {
+      width: 60px; padding: 10px 0;
+      display: flex; flex-direction: column; align-items: center;
+      gap: 4px; border-radius: 12px;
+      color: #a0aec0; cursor: pointer;
+      transition: all 0.2s; position: relative;
+    }
+    .rail-tab i { font-size: 20px; }
+    .rail-tab span { font-size: 10px; font-weight: 600; }
+    .rail-tab:hover { background: rgba(255,255,255,0.05); color: #cbd5e0; }
+    .rail-tab.active {
+      color: #fff;
+      background: rgba(102,126,234,0.15);
+    }
+    .rail-tab.active::before {
+      content: ''; position: absolute; left: -12px; top: 12px; bottom: 12px;
+      width: 4px; border-radius: 0 4px 4px 0;
+      background: linear-gradient(180deg, #667eea, #764ba2);
+    }
+    .rail-spacer { flex: 1; }
+    .rail-user {
+      width: 44px; height: 44px; border-radius: 50%;
+      background: #4a5568; color: white;
+      display: flex; align-items: center; justify-content: center;
+      font-weight: 600; font-size: 14px;
+      cursor: pointer;
+    }
+
+    /* === ACCOUNTS PANEL === */
+    .accounts {
+      width: 300px;
+      background: #fff;
+      border-right: 1px solid #e2e8f0;
+      display: flex;
+      flex-direction: column;
+    }
+    .accounts-header {
+      padding: 18px 20px 14px;
+      border-bottom: 1px solid #edf2f7;
+    }
+    .accounts-title {
+      font-size: 11px; font-weight: 700; color: #a0aec0;
+      text-transform: uppercase; letter-spacing: 0.6px; margin-bottom: 4px;
+    }
+    .accounts-total {
+      font-size: 22px; font-weight: 700; color: #2d3748;
+    }
+    .accounts-sub { font-size: 12px; color: #718096; margin-top: 2px; }
+
+    .accounts-list { flex: 1; overflow-y: auto; padding: 12px 8px; }
+    .account-group-title {
+      padding: 10px 12px 6px; font-size: 11px; font-weight: 700;
+      color: #a0aec0; text-transform: uppercase; letter-spacing: 0.5px;
+    }
+    .account-item {
+      padding: 10px 12px; border-radius: 8px; cursor: pointer;
+      display: flex; align-items: center; gap: 10px;
+      transition: background 0.15s;
+    }
+    .account-item:hover { background: #f7fafc; }
+    .account-item.active { background: #edf2ff; }
+    .account-item.active .account-name { color: #5a67d8; font-weight: 600; }
+    .account-color {
+      width: 8px; height: 32px; border-radius: 4px;
+      background: linear-gradient(180deg, #667eea, #764ba2);
+    }
+    .account-body { flex: 1; min-width: 0; }
+    .account-name {
+      font-size: 13px; font-weight: 500; color: #2d3748;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .account-bank { font-size: 11px; color: #a0aec0; }
+    .account-amount { font-size: 13px; font-weight: 600; color: #2d3748; }
+    .account-amount.neg { color: #e53e3e; }
+
+    /* === MAIN CONTENT === */
+    .main {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .main-header {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      padding: 22px 32px;
+      color: white;
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-end;
+    }
+    .mh-left .mh-title { font-size: 13px; opacity: 0.85; margin-bottom: 4px; }
+    .mh-left .mh-account { font-size: 22px; font-weight: 700; margin-bottom: 8px; }
+    .mh-left .mh-balance { font-size: 36px; font-weight: 800; line-height: 1; }
+    .mh-right { display: flex; gap: 24px; align-items: flex-end; }
+    .mh-stat {
+      display: flex; flex-direction: column; align-items: flex-end;
+    }
+    .mh-stat-label { font-size: 11px; opacity: 0.85; }
+    .mh-stat-value { font-size: 16px; font-weight: 700; }
+    .mh-actions { display: flex; gap: 10px; }
+    .mh-icon-btn {
+      width: 38px; height: 38px; border-radius: 10px;
+      background: rgba(255,255,255,0.15);
+      display: flex; align-items: center; justify-content: center;
+      color: white; cursor: pointer; transition: background 0.15s;
+    }
+    .mh-icon-btn:hover { background: rgba(255,255,255,0.25); }
+
+    /* Operations table (like a desktop view) */
+    .ops-toolbar {
+      padding: 14px 28px; display: flex; justify-content: space-between;
+      align-items: center; border-bottom: 1px solid #edf2f7; background: #fff;
+    }
+    .ops-tabs { display: flex; gap: 8px; }
+    .ops-tab {
+      padding: 6px 14px; border-radius: 18px; font-size: 13px;
+      color: #718096; cursor: pointer; font-weight: 500;
+    }
+    .ops-tab.active { background: #edf2ff; color: #5a67d8; font-weight: 600; }
+    .ops-search {
+      width: 240px; padding: 8px 12px 8px 34px; border-radius: 8px;
+      border: 1px solid #e2e8f0; font-size: 13px; background: #f7fafc url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23a0aec0'><path d='M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z'/></svg>") no-repeat 10px center;
+      background-size: 14px;
+    }
+
+    .ops-list { flex: 1; overflow-y: auto; background: #f8fafc; padding: 12px 20px 80px; }
+    .op-row {
+      display: grid;
+      grid-template-columns: 80px 36px 1fr 120px 90px 110px 36px;
+      align-items: center;
+      gap: 12px;
+      background: white;
+      border-radius: 10px;
+      padding: 12px 16px;
+      margin-bottom: 6px;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.03);
+      cursor: pointer;
+      transition: all 0.15s;
+    }
+    .op-row:hover { box-shadow: 0 4px 8px rgba(0,0,0,0.06); transform: translateY(-1px); }
+    .op-date { font-size: 12px; color: #a0aec0; font-weight: 500; }
+    .op-icon {
+      width: 36px; height: 36px; border-radius: 50%; background: #edf2f7;
+      display: flex; align-items: center; justify-content: center;
+      color: #4a5568; font-size: 14px;
+    }
+    .op-name { font-size: 14px; font-weight: 600; color: #2d3748; }
+    .op-cat-pill {
+      display: inline-block; padding: 3px 10px; border-radius: 12px;
+      font-size: 11px; font-weight: 600; background: #edf2f7; color: #4a5568;
+    }
+    .op-amount { font-size: 14px; font-weight: 700; text-align: right; }
+    .op-amount.pos { color: #38a169; }
+    .op-amount.neg { color: #e53e3e; }
+    .op-check {
+      width: 24px; height: 24px; border-radius: 50%;
+      border: 2px solid #cbd5e0; display: flex;
+      align-items: center; justify-content: center;
+      color: transparent; transition: all 0.15s;
+    }
+    .op-check.checked {
+      background: #38a169; border-color: #38a169; color: white;
+    }
+    .op-check.checked i { font-size: 11px; }
+    .op-action { color: #cbd5e0; font-size: 14px; }
+
+    /* === FAB === */
+    .fab-container {
+      position: absolute; right: 32px; bottom: 32px;
+      display: flex; flex-direction: column-reverse; align-items: flex-end;
+      gap: 14px; z-index: 100;
+    }
+    .fab {
+      width: 64px; height: 64px; border-radius: 50%;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white; border: none; cursor: pointer;
+      display: flex; align-items: center; justify-content: center;
+      box-shadow: 0 12px 28px rgba(102,126,234,0.45);
+      font-size: 24px;
+      transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    }
+    .fab:hover { transform: scale(1.05); }
+    .fab.expanded { transform: rotate(45deg); }
+    .mini-fab {
+      display: flex; align-items: center; gap: 12px;
+      animation: popIn 0.25s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
+    }
+    .mini-fab .label {
+      background: #2d3748; color: white;
+      padding: 8px 14px; border-radius: 8px;
+      font-size: 13px; font-weight: 600;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    }
+    .mini-fab .btn {
+      width: 50px; height: 50px; border-radius: 50%;
+      display: flex; align-items: center; justify-content: center;
+      color: white; font-size: 18px;
+      box-shadow: 0 6px 16px rgba(0,0,0,0.2);
+    }
+    .mini-fab:nth-of-type(1) { animation-delay: 0.05s; }
+    .mini-fab:nth-of-type(2) { animation-delay: 0.1s; }
+    .mini-fab:nth-of-type(3) { animation-delay: 0.15s; }
+    .mini-fab:nth-of-type(1) .btn { background: linear-gradient(135deg, #ffc107, #e0a800); color: #212529; }
+    .mini-fab:nth-of-type(2) .btn { background: linear-gradient(135deg, #007bff, #0056b3); }
+    .mini-fab:nth-of-type(3) .btn { background: linear-gradient(135deg, #17a2b8, #117a8b); }
+    @keyframes popIn {
+      from { opacity: 0; transform: translateY(10px) scale(0.85); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    .fab-backdrop {
+      position: absolute; inset: 0;
+      background: rgba(0,0,0,0.25);
+      backdrop-filter: blur(2px);
+      z-index: 50;
+    }
+
+    /* === PATRIMOINE HUB === */
+    .patrimoine-content {
+      flex: 1; padding: 28px 36px 100px; overflow-y: auto; background: #f8fafc;
+    }
+    .pat-section-title {
+      font-size: 12px; font-weight: 700; color: #a0aec0;
+      text-transform: uppercase; letter-spacing: 0.6px; margin-bottom: 14px;
+    }
+
+    .pat-summary {
+      display: grid; grid-template-columns: repeat(4, 1fr);
+      gap: 14px; margin-bottom: 28px;
+    }
+    .pat-summary-card {
+      background: white; padding: 18px 20px; border-radius: 14px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.04);
+    }
+    .pat-summary-label {
+      font-size: 12px; color: #718096; margin-bottom: 6px;
+    }
+    .pat-summary-value {
+      font-size: 22px; font-weight: 700; color: #2d3748;
+    }
+    .pat-summary-delta {
+      font-size: 11px; font-weight: 600; margin-top: 4px;
+    }
+    .pat-summary-delta.pos { color: #38a169; }
+    .pat-summary-delta.neg { color: #e53e3e; }
+
+    .pat-grid {
+      display: grid; grid-template-columns: repeat(4, 1fr);
+      gap: 16px;
+    }
+    .pat-card {
+      background: white; border-radius: 16px; padding: 22px;
+      cursor: pointer; transition: all 0.2s;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+      position: relative; overflow: hidden;
+    }
+    .pat-card:hover {
+      transform: translateY(-4px); box-shadow: 0 12px 24px rgba(0,0,0,0.1);
+    }
+    .pat-icon {
+      width: 56px; height: 56px; border-radius: 14px;
+      display: flex; align-items: center; justify-content: center;
+      color: white; font-size: 22px; margin-bottom: 14px;
+    }
+    .pi-bien { background: linear-gradient(135deg, #e83e8c 0%, #c42a60 100%); }
+    .pi-credit { background: linear-gradient(135deg, #6f42c1 0%, #4e2a8e 100%); }
+    .pi-recur { background: linear-gradient(135deg, #17a2b8 0%, #117a8b 100%); }
+    .pi-amort { background: linear-gradient(135deg, #28a745 0%, #1e7e34 100%); }
+
+    .pat-label { font-size: 16px; font-weight: 700; color: #2d3748; margin-bottom: 4px; }
+    .pat-count { font-size: 13px; color: #a0aec0; margin-bottom: 12px; }
+    .pat-amount { font-size: 18px; font-weight: 700; color: #2d3748; }
+    .pat-arrow {
+      position: absolute; top: 22px; right: 22px;
+      color: #cbd5e0; font-size: 14px;
+    }
+
+    /* === DESCRIPTION === */
+    .description {
+      max-width: 1180px;
+      margin: 48px auto 0;
+      background: white;
+      padding: 32px 40px;
+      border-radius: 16px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+    }
+    .description h2 {
+      color: #2d3748; margin-bottom: 14px; font-size: 20px;
+    }
+    .description ul { padding-left: 24px; line-height: 1.9; color: #4a5568; }
+    .description strong { color: #2d3748; }
+    .description code {
+      background: #edf2f7; padding: 2px 6px; border-radius: 4px;
+      font-size: 13px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Option 3 — Desktop / iPad paysage</h1>
+  <p class="subtitle">Rail vertical à gauche · panneau comptes · contenu principal · FAB contextuel</p>
+
+  <div class="screens">
+
+    <!-- ========== ÉCRAN 1 : Comptes ========== -->
+    <div class="screen-wrapper">
+      <div class="screen-label">1. Onglet Comptes — vue desktop classique</div>
+      <div class="ipad">
+        <div class="layout">
+
+          <!-- Rail nav -->
+          <div class="nav-rail">
+            <div class="logo">M</div>
+            <div class="rail-tab active">
+              <i class="fas fa-wallet"></i>
+              <span>Comptes</span>
+            </div>
+            <div class="rail-tab">
+              <i class="fas fa-building"></i>
+              <span>Patrimoine</span>
+            </div>
+            <div class="rail-tab">
+              <i class="fas fa-chart-pie"></i>
+              <span>Stats</span>
+            </div>
+            <div class="rail-tab">
+              <i class="fas fa-cog"></i>
+              <span>Réglages</span>
+            </div>
+            <div class="rail-spacer"></div>
+            <div class="rail-user">JX</div>
+          </div>
+
+          <!-- Comptes panel -->
+          <div class="accounts">
+            <div class="accounts-header">
+              <div class="accounts-title">Solde global</div>
+              <div class="accounts-total">14 832,11 €</div>
+              <div class="accounts-sub">8 comptes · 3 banques</div>
+            </div>
+            <div class="accounts-list">
+              <div class="account-group-title">Disponible</div>
+              <div class="account-item active">
+                <div class="account-color"></div>
+                <div class="account-body">
+                  <div class="account-name">Compte courant</div>
+                  <div class="account-bank">BNP Paribas</div>
+                </div>
+                <div class="account-amount">2 458 €</div>
+              </div>
+              <div class="account-item">
+                <div class="account-color" style="background: linear-gradient(180deg, #38a169, #2f855a);"></div>
+                <div class="account-body">
+                  <div class="account-name">Livret A</div>
+                  <div class="account-bank">BNP Paribas</div>
+                </div>
+                <div class="account-amount">12 200 €</div>
+              </div>
+              <div class="account-item">
+                <div class="account-color" style="background: linear-gradient(180deg, #ed8936, #dd6b20);"></div>
+                <div class="account-body">
+                  <div class="account-name">Compte joint</div>
+                  <div class="account-bank">Crédit Agricole</div>
+                </div>
+                <div class="account-amount">3 290 €</div>
+              </div>
+              <div class="account-group-title" style="margin-top: 8px;">Bloqué</div>
+              <div class="account-item">
+                <div class="account-color" style="background: linear-gradient(180deg, #4299e1, #2b6cb0);"></div>
+                <div class="account-body">
+                  <div class="account-name">PEA</div>
+                  <div class="account-bank">Boursorama</div>
+                </div>
+                <div class="account-amount">8 410 €</div>
+              </div>
+              <div class="account-item">
+                <div class="account-color" style="background: linear-gradient(180deg, #9f7aea, #6b46c1);"></div>
+                <div class="account-body">
+                  <div class="account-name">Assurance vie</div>
+                  <div class="account-bank">Boursorama</div>
+                </div>
+                <div class="account-amount">22 100 €</div>
+              </div>
+              <div class="account-group-title" style="margin-top: 8px;">Retraite</div>
+              <div class="account-item">
+                <div class="account-color" style="background: linear-gradient(180deg, #ec4899, #be185d);"></div>
+                <div class="account-body">
+                  <div class="account-name">PER</div>
+                  <div class="account-bank">Boursorama</div>
+                </div>
+                <div class="account-amount">5 220 €</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Main -->
+          <div class="main">
+            <div class="main-header">
+              <div class="mh-left">
+                <div class="mh-title">BNP Paribas · Compte courant</div>
+                <div class="mh-account">Compte courant</div>
+                <div class="mh-balance">2 458,32 €</div>
+              </div>
+              <div class="mh-right">
+                <div class="mh-stat">
+                  <span class="mh-stat-label">Pointé</span>
+                  <span class="mh-stat-value">2 578,82 €</span>
+                </div>
+                <div class="mh-stat">
+                  <span class="mh-stat-label">À pointer</span>
+                  <span class="mh-stat-value">-120,50 €</span>
+                </div>
+                <div class="mh-actions">
+                  <div class="mh-icon-btn"><i class="fas fa-eye"></i></div>
+                  <div class="mh-icon-btn"><i class="fas fa-ellipsis-h"></i></div>
+                </div>
+              </div>
+            </div>
+
+            <div class="ops-toolbar">
+              <div class="ops-tabs">
+                <div class="ops-tab active">Toutes</div>
+                <div class="ops-tab">À pointer</div>
+                <div class="ops-tab">Pointées</div>
+              </div>
+              <input class="ops-search" placeholder="Rechercher une opération..." />
+            </div>
+
+            <div class="ops-list">
+              <div class="op-row">
+                <div class="op-date">02/05/2026</div>
+                <div class="op-icon"><i class="fas fa-shopping-cart"></i></div>
+                <div>
+                  <div class="op-name">Carrefour</div>
+                </div>
+                <div><span class="op-cat-pill">Courses</span></div>
+                <div class="op-amount neg">-58,40 €</div>
+                <div class="op-check"><i class="fas fa-check"></i></div>
+                <div class="op-action"><i class="fas fa-ellipsis-v"></i></div>
+              </div>
+              <div class="op-row">
+                <div class="op-date">30/04/2026</div>
+                <div class="op-icon"><i class="fas fa-money-bill-wave"></i></div>
+                <div><div class="op-name">Salaire avril</div></div>
+                <div><span class="op-cat-pill">Revenus</span></div>
+                <div class="op-amount pos">+2 800,00 €</div>
+                <div class="op-check checked"><i class="fas fa-check"></i></div>
+                <div class="op-action"><i class="fas fa-ellipsis-v"></i></div>
+              </div>
+              <div class="op-row">
+                <div class="op-date">28/04/2026</div>
+                <div class="op-icon"><i class="fas fa-bolt"></i></div>
+                <div><div class="op-name">EDF</div></div>
+                <div><span class="op-cat-pill">Énergie</span></div>
+                <div class="op-amount neg">-89,12 €</div>
+                <div class="op-check checked"><i class="fas fa-check"></i></div>
+                <div class="op-action"><i class="fas fa-ellipsis-v"></i></div>
+              </div>
+              <div class="op-row">
+                <div class="op-date">27/04/2026</div>
+                <div class="op-icon"><i class="fas fa-utensils"></i></div>
+                <div><div class="op-name">Restaurant Le Bistrot</div></div>
+                <div><span class="op-cat-pill">Restaurants</span></div>
+                <div class="op-amount neg">-42,00 €</div>
+                <div class="op-check checked"><i class="fas fa-check"></i></div>
+                <div class="op-action"><i class="fas fa-ellipsis-v"></i></div>
+              </div>
+              <div class="op-row">
+                <div class="op-date">25/04/2026</div>
+                <div class="op-icon"><i class="fas fa-gas-pump"></i></div>
+                <div><div class="op-name">Total Énergies</div></div>
+                <div><span class="op-cat-pill">Carburant</span></div>
+                <div class="op-amount neg">-72,80 €</div>
+                <div class="op-check checked"><i class="fas fa-check"></i></div>
+                <div class="op-action"><i class="fas fa-ellipsis-v"></i></div>
+              </div>
+              <div class="op-row">
+                <div class="op-date">24/04/2026</div>
+                <div class="op-icon"><i class="fas fa-home"></i></div>
+                <div><div class="op-name">Loyer mai 2026</div></div>
+                <div><span class="op-cat-pill">Logement</span></div>
+                <div class="op-amount neg">-850,00 €</div>
+                <div class="op-check checked"><i class="fas fa-check"></i></div>
+                <div class="op-action"><i class="fas fa-ellipsis-v"></i></div>
+              </div>
+            </div>
+
+            <!-- FAB -->
+            <div class="fab-container">
+              <button class="fab"><i class="fas fa-plus"></i></button>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+
+    <!-- ========== ÉCRAN 2 : FAB déployé ========== -->
+    <div class="screen-wrapper">
+      <div class="screen-label">2. FAB déployé — actions contextuelles (onglet Comptes)</div>
+      <div class="ipad">
+        <div class="layout">
+
+          <div class="nav-rail">
+            <div class="logo">M</div>
+            <div class="rail-tab active">
+              <i class="fas fa-wallet"></i>
+              <span>Comptes</span>
+            </div>
+            <div class="rail-tab">
+              <i class="fas fa-building"></i>
+              <span>Patrimoine</span>
+            </div>
+            <div class="rail-tab">
+              <i class="fas fa-chart-pie"></i>
+              <span>Stats</span>
+            </div>
+            <div class="rail-tab">
+              <i class="fas fa-cog"></i>
+              <span>Réglages</span>
+            </div>
+            <div class="rail-spacer"></div>
+            <div class="rail-user">JX</div>
+          </div>
+
+          <div class="accounts">
+            <div class="accounts-header">
+              <div class="accounts-title">Solde global</div>
+              <div class="accounts-total">14 832,11 €</div>
+              <div class="accounts-sub">8 comptes · 3 banques</div>
+            </div>
+            <div class="accounts-list">
+              <div class="account-group-title">Disponible</div>
+              <div class="account-item active">
+                <div class="account-color"></div>
+                <div class="account-body">
+                  <div class="account-name">Compte courant</div>
+                  <div class="account-bank">BNP Paribas</div>
+                </div>
+                <div class="account-amount">2 458 €</div>
+              </div>
+              <div class="account-item">
+                <div class="account-color" style="background: linear-gradient(180deg, #38a169, #2f855a);"></div>
+                <div class="account-body">
+                  <div class="account-name">Livret A</div>
+                  <div class="account-bank">BNP Paribas</div>
+                </div>
+                <div class="account-amount">12 200 €</div>
+              </div>
+              <div class="account-item">
+                <div class="account-color" style="background: linear-gradient(180deg, #ed8936, #dd6b20);"></div>
+                <div class="account-body">
+                  <div class="account-name">Compte joint</div>
+                  <div class="account-bank">Crédit Agricole</div>
+                </div>
+                <div class="account-amount">3 290 €</div>
+              </div>
+            </div>
+          </div>
+
+          <div class="main">
+            <div class="main-header">
+              <div class="mh-left">
+                <div class="mh-title">BNP Paribas · Compte courant</div>
+                <div class="mh-account">Compte courant</div>
+                <div class="mh-balance">2 458,32 €</div>
+              </div>
+              <div class="mh-right">
+                <div class="mh-stat">
+                  <span class="mh-stat-label">Pointé</span>
+                  <span class="mh-stat-value">2 578,82 €</span>
+                </div>
+                <div class="mh-stat">
+                  <span class="mh-stat-label">À pointer</span>
+                  <span class="mh-stat-value">-120,50 €</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="ops-toolbar">
+              <div class="ops-tabs">
+                <div class="ops-tab active">Toutes</div>
+                <div class="ops-tab">À pointer</div>
+                <div class="ops-tab">Pointées</div>
+              </div>
+              <input class="ops-search" placeholder="Rechercher une opération..." />
+            </div>
+
+            <div class="ops-list">
+              <div class="op-row">
+                <div class="op-date">02/05/2026</div>
+                <div class="op-icon"><i class="fas fa-shopping-cart"></i></div>
+                <div><div class="op-name">Carrefour</div></div>
+                <div><span class="op-cat-pill">Courses</span></div>
+                <div class="op-amount neg">-58,40 €</div>
+                <div class="op-check"><i class="fas fa-check"></i></div>
+                <div class="op-action"><i class="fas fa-ellipsis-v"></i></div>
+              </div>
+              <div class="op-row">
+                <div class="op-date">30/04/2026</div>
+                <div class="op-icon"><i class="fas fa-money-bill-wave"></i></div>
+                <div><div class="op-name">Salaire avril</div></div>
+                <div><span class="op-cat-pill">Revenus</span></div>
+                <div class="op-amount pos">+2 800,00 €</div>
+                <div class="op-check checked"><i class="fas fa-check"></i></div>
+                <div class="op-action"><i class="fas fa-ellipsis-v"></i></div>
+              </div>
+            </div>
+
+            <div class="fab-backdrop"></div>
+            <div class="fab-container">
+              <button class="fab expanded"><i class="fas fa-plus"></i></button>
+              <div class="mini-fab">
+                <span class="label">Virement entre comptes</span>
+                <div class="btn"><i class="fas fa-exchange-alt"></i></div>
+              </div>
+              <div class="mini-fab">
+                <span class="label">Nouvelle opération</span>
+                <div class="btn"><i class="fas fa-pen"></i></div>
+              </div>
+              <div class="mini-fab">
+                <span class="label">Rechercher</span>
+                <div class="btn"><i class="fas fa-search"></i></div>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+
+    <!-- ========== ÉCRAN 3 : Patrimoine ========== -->
+    <div class="screen-wrapper">
+      <div class="screen-label">3. Onglet Patrimoine — hub avec cartes et résumé</div>
+      <div class="ipad">
+        <div class="layout">
+
+          <div class="nav-rail">
+            <div class="logo">M</div>
+            <div class="rail-tab">
+              <i class="fas fa-wallet"></i>
+              <span>Comptes</span>
+            </div>
+            <div class="rail-tab active">
+              <i class="fas fa-building"></i>
+              <span>Patrimoine</span>
+            </div>
+            <div class="rail-tab">
+              <i class="fas fa-chart-pie"></i>
+              <span>Stats</span>
+            </div>
+            <div class="rail-tab">
+              <i class="fas fa-cog"></i>
+              <span>Réglages</span>
+            </div>
+            <div class="rail-spacer"></div>
+            <div class="rail-user">JX</div>
+          </div>
+
+          <!-- Pas de panneau "comptes" sur l'onglet Patrimoine : la zone main occupe toute la largeur restante -->
+          <div class="main">
+            <div class="main-header">
+              <div class="mh-left">
+                <div class="mh-title">Vue d'ensemble</div>
+                <div class="mh-account">Patrimoine</div>
+                <div class="mh-balance">412 580 €</div>
+              </div>
+              <div class="mh-right">
+                <div class="mh-stat">
+                  <span class="mh-stat-label">Plus-value latente</span>
+                  <span class="mh-stat-value">+18 200 €</span>
+                </div>
+                <div class="mh-stat">
+                  <span class="mh-stat-label">Reste à rembourser</span>
+                  <span class="mh-stat-value">-187 400 €</span>
+                </div>
+                <div class="mh-actions">
+                  <div class="mh-icon-btn"><i class="fas fa-eye"></i></div>
+                  <div class="mh-icon-btn"><i class="fas fa-download"></i></div>
+                </div>
+              </div>
+            </div>
+
+            <div class="patrimoine-content">
+              <div class="pat-section-title">Aperçu</div>
+              <div class="pat-summary">
+                <div class="pat-summary-card">
+                  <div class="pat-summary-label">Valeur immobilière</div>
+                  <div class="pat-summary-value">385 000 €</div>
+                  <div class="pat-summary-delta pos">+ 4,9 % YTD</div>
+                </div>
+                <div class="pat-summary-card">
+                  <div class="pat-summary-label">Capital remboursé</div>
+                  <div class="pat-summary-value">62 350 €</div>
+                  <div class="pat-summary-delta pos">+ 8 200 € en 2026</div>
+                </div>
+                <div class="pat-summary-card">
+                  <div class="pat-summary-label">Mensualités totales</div>
+                  <div class="pat-summary-value">1 480 €</div>
+                  <div class="pat-summary-delta">3 crédits actifs</div>
+                </div>
+                <div class="pat-summary-card">
+                  <div class="pat-summary-label">Cash-flow locatif</div>
+                  <div class="pat-summary-value">+ 220 €</div>
+                  <div class="pat-summary-delta pos">par mois</div>
+                </div>
+              </div>
+
+              <div class="pat-section-title">Mes outils</div>
+              <div class="pat-grid">
+                <div class="pat-card">
+                  <div class="pat-icon pi-bien"><i class="fas fa-home"></i></div>
+                  <div class="pat-arrow"><i class="fas fa-chevron-right"></i></div>
+                  <div class="pat-label">Biens</div>
+                  <div class="pat-count">2 biens immobiliers</div>
+                  <div class="pat-amount">385 000 €</div>
+                </div>
+                <div class="pat-card">
+                  <div class="pat-icon pi-credit"><i class="fas fa-credit-card"></i></div>
+                  <div class="pat-arrow"><i class="fas fa-chevron-right"></i></div>
+                  <div class="pat-label">Crédits</div>
+                  <div class="pat-count">3 crédits actifs</div>
+                  <div class="pat-amount">- 187 400 €</div>
+                </div>
+                <div class="pat-card">
+                  <div class="pat-icon pi-recur"><i class="fas fa-retweet"></i></div>
+                  <div class="pat-arrow"><i class="fas fa-chevron-right"></i></div>
+                  <div class="pat-label">Récurrentes</div>
+                  <div class="pat-count">12 opérations</div>
+                  <div class="pat-amount">- 1 920 € / mois</div>
+                </div>
+                <div class="pat-card">
+                  <div class="pat-icon pi-amort"><i class="fas fa-history"></i></div>
+                  <div class="pat-arrow"><i class="fas fa-chevron-right"></i></div>
+                  <div class="pat-label">Amortissement</div>
+                  <div class="pat-count">Suivi 2026</div>
+                  <div class="pat-amount">62 350 € remboursé</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- FAB contextuel : sur Patrimoine, le + ouvre les créations Bien/Crédit/Récurrente -->
+            <div class="fab-container">
+              <button class="fab"><i class="fas fa-plus"></i></button>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="description">
+    <h2>Adaptation Desktop / iPad paysage</h2>
+    <ul>
+      <li><strong>Rail vertical fixe à gauche</strong> (84 px) : remplace la barre du bas du mobile. Les 4 onglets sont toujours visibles avec un indicateur lumineux sur l'onglet actif. Le rail est sombre pour faire respirer la zone de contenu.</li>
+      <li><strong>Trois colonnes sur l'onglet Comptes</strong> : rail · liste des comptes (300 px) · contenu principal. La liste des comptes apparaît uniquement quand elle est pertinente — sur les autres onglets, le contenu principal s'étale sur toute la largeur.</li>
+      <li><strong>Tableau d'opérations enrichi</strong> : sur grand écran on tire parti de la largeur (date · icône · nom · catégorie · montant · check · menu). Sur mobile, ces colonnes s'empilent comme aujourd'hui.</li>
+      <li><strong>Hub Patrimoine</strong> : un header avec patrimoine total et plus-value, 4 cartes de KPI en haut (valeur immo, capital remboursé, mensualités totales, cash-flow locatif) puis la grille des 4 outils. C'est la vue qui justifie le mieux le mode paysage.</li>
+      <li><strong>FAB en bas-droite du contenu</strong>, pas de l'écran : il se positionne dans la zone qu'il commande. Speed-dial avec labels textuels (le hover desktop donne plus de place qu'un long-press mobile).</li>
+      <li><strong>Avatar utilisateur</strong> en bas du rail : remplace le bouton réglages discret + permet de switcher d'utilisateur ou se déconnecter.</li>
+    </ul>
+    <h2 style="margin-top: 24px;">Composants à créer / refactorer</h2>
+    <ul>
+      <li><code>NavRail.vue</code> (desktop) + <code>BottomTabs.vue</code> (mobile) qui partagent le même contrat de tabs</li>
+      <li><code>FabMenu.vue</code> avec slot pour mini-actions contextuelles à chaque vue</li>
+      <li><code>Patrimoine.vue</code> : nouvelle vue hub, KPI calculés à partir des stores existants <code>credit</code> et <code>bien</code></li>
+      <li>Ajustement de <code>App.vue</code> : layout en grid (rail / accounts / main) plutôt qu'en flex avec navbar bottom</li>
+    </ul>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Add a new "Bien" entity to manage real estate properties: name, city,
type (appartement/maison/terrain/parking/local), surface, usage
(résidence principale/secondaire/locatif), purchase date, and a price
breakdown (prix nu, frais de notaire, frais d'agence). Optional fields
for cash down payment, current estimated value, and an associated
credit selected from existing user credits.

Backend: Bien model/repository/controller with JWT-authenticated CRUD
scoped to the current user, including ownership check on linked credits.

Frontend: dedicated /biens view with summary cards (count, total
investment, estimated value), list/card components, and a form
overlay reachable via a new home-icon button in the bottom NavBar.

https://claude.ai/code/session_019P69iVGiCzNXM9efANXtZn