### PR TITLE
docs: refresh README and CLAUDE.md files to cover full functional scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,46 +4,53 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**mccbng** (mCloud Compte and Budget Next Generation) is a personal finance and budgeting application. It is structured as a Yarn workspaces monorepo with three packages:
+**mccbng** (mCloud Compte and Budget Next Generation) is a personal finance and budgeting application. It is structured as a **pnpm workspaces** monorepo with two packages:
 
-- `back/` — LoopBack 4 REST API with JWT authentication and MySQL database
-- `front/` — Vue 3 SPA with TypeScript, Vite, Vuex, and PWA support
-- `vue-touch-events/` — Custom Vue 3 touch events plugin (fork of vue2-touch-events adapted for Vue 3)
+- `back/` — LoopBack 4 REST API with JWT authentication and MySQL database.
+- `front/` — Vue 3 SPA with TypeScript, Vite, Vuex 4, and PWA support.
+
+> The `vue-touch-events/` workspace mentioned in older docs has been removed: the front-end now depends on the published `vue3-touch-events` npm package.
 
 See `back/CLAUDE.md` and `front/CLAUDE.md` for detailed architecture documentation of each package.
 
 ## Development Commands
 
 ### Root Level
+
 ```bash
-yarn install           # Install all workspace dependencies (uses Yarn workspaces)
+pnpm install                        # install all workspace dependencies
+pnpm --filter @mccbng/back <cmd>    # run a script in back/
+pnpm --filter @mccbng/front <cmd>   # run a script in front/
 ```
 
 ### Backend (`back/`)
+
 ```bash
 cd back
-yarn build              # Compile TypeScript (lb-tsc)
-yarn build:watch        # Watch mode compilation
-yarn start              # Run production server (node -r source-map-support/register .)
-yarn lint               # Run ESLint and Prettier checks
-yarn lint:fix           # Fix linting issues
-yarn test               # Run tests with Mocha
-yarn clean              # Clean build artifacts
-yarn migrate            # Run database migrations (builds first via premigrate hook)
+pnpm build              # Compile TypeScript (lb-tsc)
+pnpm build:watch        # Watch mode compilation
+pnpm start              # Rebuild + run production server (node -r source-map-support/register .)
+pnpm lint               # Run ESLint and Prettier checks
+pnpm lint:fix           # Fix linting issues
+pnpm test               # Run tests with Mocha (rebuild + run)
+pnpm clean              # Clean build artifacts (lb-clean dist *.tsbuildinfo .eslintcache)
+pnpm migrate            # Run database migrations (auto-builds via premigrate hook)
+pnpm openapi-spec       # Generate OpenAPI spec
 ```
 
 ### Frontend (`front/`)
+
 ```bash
 cd front
-yarn dev                # Development server with Vite (port 8080)
-yarn build              # Production build
-yarn build:staging      # Staging build (--mode test)
-yarn test               # Run Jest tests
-yarn test:unit          # Unit tests only
-yarn test:coverage      # Tests with coverage
-yarn type-check         # TypeScript type checking (vue-tsc --noEmit)
-yarn lint               # ESLint with auto-fix
-yarn lint:check         # ESLint check only (no auto-fix)
+pnpm dev                # Development server with Vite (port 8080)
+pnpm build              # Production build
+pnpm build:staging      # Staging build (--mode test)
+pnpm test               # Run Jest tests
+pnpm test:unit          # Unit tests only
+pnpm test:coverage      # Tests with coverage
+pnpm type-check         # TypeScript type checking (vue-tsc --noEmit)
+pnpm lint               # ESLint with auto-fix
+pnpm lint:check         # ESLint check only (no auto-fix)
 ```
 
 ## Architecture Overview
@@ -58,63 +65,93 @@ yarn lint:check         # ESLint check only (no auto-fix)
   (port 8080)          /api            (port 3000)
 ```
 
-1. The frontend authenticates via `POST /api/users/login` with a 6-character secret code
-2. The API returns a JWT token stored in cookies (`userToken`, `userID`)
-3. All subsequent API calls include `Authorization: Bearer <token>` header
-4. The Vite dev server proxies `/api` requests to the backend
+1. The frontend authenticates via `POST /api/users/login` with a 6-character `code` (the user's `secret_key`).
+2. The API returns a JWT token issued by the custom `JwtService` (which preserves the numeric `IDuser` field through the token round-trip).
+3. The token is stored in cookies (`userToken`, `userID`) via `universal-cookie`. All subsequent API calls include `Authorization: Bearer <token>`.
+4. The Vite dev server proxies `/api` to the backend (`VITE_API_URL`).
+5. The JWT secret is regenerated on every backend restart (`generateUniqueId()` bound to `TokenServiceBindings.TOKEN_SECRET`) — tokens are invalidated when the API restarts.
 
 ### Domain Model
 
-The application manages personal finances with this hierarchy:
+| Entity | Key | Notes |
+|--------|-----|-------|
+| **User** | `id` (UUID) + `IDuser` (numeric, used in JWT) | hasOne `UserCredentials`. `secret_key` is the 6-char login code. |
+| **Banque** | `IDbanque` | Bank — groups accounts. |
+| **Compte** | `IDcompte` | Bank account. Type flags: `bloque`, `joint`, `children`, `retraite`, `porte_feuille`, `visible`. belongsTo `Banque`. |
+| **Operation** | `IDop` | Single transaction. Belongs to a `Compte`, optionally tied to a `Categorie` and a `Credit`. `CheckOp` = pointed/checked status, `amortissement` flag. |
+| **OperationRecurrente** | `IDopRecu` | Recurring template. `Frequence`: 3 = monthly, 7 = yearly. `DernierDateOpRecu` tracks last generation. |
+| **Categorie** | `IDcat` | User-defined classification. `Stats` flag toggles inclusion in monthly stats. |
+| **Credit** | `IDcredit` | Loan / mortgage. Auto-creates a monthly `OperationRecurrente` when created. |
+| **Bien** | `IDbien` | Real-estate asset. Optionally linked to a `Credit` (mortgage). |
+| **Stats** | `userID` | Support entity used by the analytics endpoints. |
 
-- **User** — Has banks, accounts, categories
-- **Banque** (Bank) — Groups accounts by financial institution
-- **Compte** (Account) — Individual bank account with balance and type flags (bloque, joint, children, retraite, porte_feuille, visible)
-- **Operation** — Single financial transaction (debit/credit) tied to an account and category
-- **OperationRecurrente** — Recurring transaction template with frequency (monthly/yearly) for auto-generation
-- **Categorie** (Category) — User-defined classification for operations, with optional stats tracking
-- **Stats** — Aggregated balance evolution data
+User scoping uses two patterns:
+
+- **Direct**: entity carries `IDuser` (`Compte`, `Categorie`, `Credit`, `Bien`). Controllers add `where: { IDuser }` via a private `scope()` helper.
+- **Inherited**: entity has no `IDuser` (`Operation`, `OperationRecurrente`). Controllers first resolve the user's `IDcompte` list, then filter with `{ IDcompte: { inq: ids } }`.
 
 ### Key Features
-- Multi-bank account management with account type classification
-- Transaction CRUD with check/uncheck status
-- Recurring operation auto-generation
-- Transfer between accounts
-- Category-based expense tracking
-- Monthly statistics with pie charts (Highcharts)
-- Balance evolution time series
-- Smart category suggestions based on operation name patterns
-- Dark/light/system theme support
-- Mobile-responsive PWA with swipe gestures
-- Amortization tracking
+
+- Multi-bank, multi-account management with type flags and pointed/unpointed balance tracking.
+- Transaction CRUD with pointed status, infinite scroll pagination (35/page), swipe-to-delete on mobile.
+- Recurring operations with monthly / yearly auto-generation.
+- Account-to-account transfers (debit + credit pair created in one shot).
+- Cross-account search by operation name.
+- Smart category suggestion based on past operation name patterns.
+- Loan tracking (`Credit`) with monthly auto-debit, remaining-balance and payment-history endpoints.
+- Real-estate tracking (`Bien`) with optional link to a `Credit` for mortgages.
+- Amortization view filtering operations flagged `amortissement = 1`.
+- Monthly statistics: total spent, pie chart by category, time series of balance evolution (global / retraite / dispo).
+- Light / dark / system theme with persistence.
+- Mobile-responsive PWA with swipeable account panel and optional Eruda debug console.
 
 ## Development Setup
 
-- **Node.js**: >=20 (see `.nvmrc`)
-- **Package Manager**: Yarn 1.22.19 (see `packageManager` in root `package.json`)
-- **Backend**: Runs on port 3000 (configurable via HOST/PORT env vars)
-- **Frontend dev server**: Runs on port 8080 with proxy to backend `/api`
+- **Node.js**: ≥ 20 (see `.nvmrc`)
+- **Package Manager**: `pnpm@10.33.0` (see `packageManager` in root `package.json`); workspace config in `pnpm-workspace.yaml`.
+- **Backend**: port 3000 (configurable via `HOST` / `PORT` env vars). API mounted at `/api`. Swagger UI at `/explorer`.
+- **Frontend**: dev server on port 8080 with `/api` proxy to `VITE_API_URL` (default `http://localhost:3000`).
 
 ### Environment Configuration
-- **Frontend**: `VITE_API_URL` — Backend API base URL (used by Vite proxy and at runtime via `window.env.VITE_API_URL`)
-- **Backend**: `back/src/datasources/mccb-mysql.datasource.config.json` — MySQL connection config (host, port, user, password, database)
+
+- **Frontend**: `VITE_API_URL` — Backend base URL (used both by the Vite proxy in dev and at runtime via `window.env.VITE_API_URL`).
+- **Backend**: `back/src/datasources/mccb-mysql.datasource.config.json` — MySQL connection config (host, port, user, password, database).
 
 ## Docker Deployments
 
 Both packages have Dockerfiles for containerized deployment:
 
-- **Backend**: `node:22-slim` base, builds TypeScript, removes source and config files for security, runs on port 3000
-- **Frontend**: Multi-stage build with `node:22-slim` + `nginx`, serves static files via nginx
+- **Backend**: `node:22-slim` base, builds TypeScript, removes `dist/datasources/*config.json` and `src/` from the image for security, runs on port 3000.
+- **Frontend**: Multi-stage `node:22-slim` → `nginx`, serves static files via nginx with SPA fallback (`try_files $uri /index.html`).
 
-Registry: `dockregistry.xju.fr/mccbng/` with `staging` and `latest` tags.
+Registry: `dockregistry.xju.fr/mccbng/{api,front}` with `staging` and `latest` tags.
 
-Docker commands available via `yarn docker:staging:build`, `yarn docker:staging:push`, `yarn docker:latest:build`, `yarn docker:latest:push` in each package.
+Each package exposes the scripts `docker:staging:build`, `docker:staging:push`, `docker:latest:build`, `docker:latest:push`. A root-level `build-and-push.sh` and `docker-compose.build.yml` are available for orchestration.
 
 ## Code Conventions
 
-- Backend uses LoopBack 4 decorators (`@model`, `@property`, `@repository`, `@authenticate('jwt')`)
-- Frontend uses Vue 3 Composition API with `<script setup lang="ts">`
-- SCSS with global variables imported via Vite's `additionalData`
-- CSS custom properties for theming (light/dark mode)
-- French naming in domain models (Banque, Compte, Operation, Categorie)
-- All financial amounts use FLOAT type with manual rounding to 2 decimal places
+- Backend uses LoopBack 4 decorators (`@model`, `@property`, `@repository`, `@authenticate('jwt')`).
+- Every protected endpoint resolves the current user via `getCurrentUserId(profile)` from `src/services/current-user.ts`, then either `scope(...)` or `assertOwned(...)` to enforce ownership before reading or writing.
+- Frontend uses Vue 3 Composition API with `<script setup lang="ts">`.
+- SCSS variables (`src/styles/variables.scss`) are globally injected via Vite's `additionalData`.
+- CSS custom properties drive light/dark theming (`src/styles/theme.css`).
+- Domain naming is in French (Banque, Compte, Operation, Categorie, Credit, Bien) — keep field/property names consistent with existing models when adding endpoints.
+- All financial amounts use the SQL `FLOAT` type with manual rounding to 2 decimal places.
+- Vue Router child routes that need a modal-style overlay should use `RouteOverTheContent` with a `componentName` prop.
+
+## Repository Layout
+
+```
+mccbng/
+├── back/                # LoopBack 4 API (see back/CLAUDE.md)
+├── front/               # Vue 3 SPA (see front/CLAUDE.md)
+├── docs/                # Functional documentation (e.g. recette-non-regression-multiuser.md)
+├── mockups/             # Standalone HTML UI mockups
+├── package.json         # Workspace root, declares pnpm packageManager
+├── pnpm-workspace.yaml  # back + front
+├── pnpm-lock.yaml
+├── docker-compose.build.yml
+├── build-and-push.sh
+├── README.md            # Functional + architectural docs (français)
+└── CLAUDE.md            # this file
+```

--- a/README.md
+++ b/README.md
@@ -1,35 +1,324 @@
 # mccbng
 
-## back
+**mccbng** (mCloud Compte and Budget Next Generation) est une application web de gestion de finances personnelles : suivi multi-banques et multi-comptes, opérations bancaires, opérations récurrentes, budget par catégorie, statistiques, suivi de crédits et de biens immobiliers.
 
-### Config files
+L'application est organisée en monorepo `pnpm` avec deux packages :
 
-- `src/datasources/mccb-mysql.datasource.config.json`
+- **`back/`** — API REST [LoopBack 4](https://loopback.io/) (Node.js / TypeScript) sur MySQL, authentification JWT.
+- **`front/`** — SPA Vue 3 (TypeScript / Vite / Vuex / PWA), avec mode sombre et gestes tactiles.
+
+---
+
+## Sommaire
+
+- [Fonctionnalités](#fonctionnalités)
+- [Architecture technique](#architecture-technique)
+- [Modèle de données](#modèle-de-données)
+- [Démarrage rapide](#démarrage-rapide)
+- [Configuration](#configuration)
+- [Déploiement Docker](#déploiement-docker)
+
+---
+
+## Fonctionnalités
+
+### Authentification et compte utilisateur
+- Connexion par **code secret à 6 caractères** (`POST /api/users/login`) — pas de mot de passe à saisir.
+- Token JWT stocké en cookies (`userToken`, `userID`) côté front, valide jusqu'au redémarrage du back (le secret est régénéré à chaque démarrage).
+- Inscription via `POST /api/signup` (réservée à un usage admin / amorçage).
+- Édition du profil (`PATCH /api/users/me`) : email, username, seuils d'alerte (`warningTotal`, `warningCompte`), favori (`favoris`).
+- Vue **Mon compte** (`/editUser`) pour la mise à jour du profil.
+
+### Comptes et banques
+- Gestion de plusieurs **banques** et plusieurs **comptes** par banque.
+- Chaque compte porte des indicateurs typés : `bloque`, `joint`, `children`, `retraite`, `porte_feuille`, `visible`.
+- Liste latérale des comptes regroupée par type (disponibles, joints, enfants, retraite, portefeuille, bloqués).
+- Calcul automatique des **soldes pointés / non pointés** par compte et des **totaux globaux** par catégorie de comptes.
+- Masquage des montants à la volée (`maskAmount` dans le module `user`).
+
+### Opérations bancaires
+- CRUD complet des opérations (débit/crédit), avec date, libellé, montant, catégorie, indicateur "pointée" (`CheckOp`) et indicateur d'amortissement.
+- Liste paginée par scroll infini (35 opérations par page) côté front.
+- **Swipe-to-delete** et clic pour éditer sur mobile.
+- **Virement** entre comptes (`/transfert`) : crée automatiquement la paire débit + crédit.
+- **Recherche** d'opérations par libellé sur tous les comptes (`/search`).
+- **Suggestion intelligente de catégorie** lors de la saisie : `GET /api/operations/suggestCategories` propose les catégories les plus fréquentes pour un libellé similaire.
+
+### Opérations récurrentes
+- Modèle de transaction récurrente avec fréquence (3 = mensuelle, 7 = annuelle), jour, mois, et date de dernière génération.
+- Génération automatique au login : `POST /api/operation-recurrentes/auto-generation` parcourt toutes les récurrentes de l'utilisateur et insère les opérations manquantes selon le délai écoulé.
+- Vue dédiée `/recurrOperation` pour la gestion (création, édition, suppression).
+
+### Catégorisation et budget
+- **Catégories** définies par utilisateur, avec un drapeau `Stats` indiquant si elles entrent dans les statistiques de dépense.
+- Vue **Statistiques** (`/stats`) :
+  - Somme mensuelle des dépenses (`GET /api/operations/sumByUserByMonth`).
+  - Répartition par catégorie en **camembert Highcharts** (`GET /api/operations/sumCategoriesByUserByMonth`).
+  - **Évolution temporelle** des soldes (global, retraite, disponible) en time series (`GET /api/stats/evolutionSolde`).
+  - Sélecteurs mois / année.
+
+### Crédits (emprunts)
+- Modèle **Credit** : nom, prêteur, montant initial, mensualité, taux d'intérêt, date début / fin, compte associé, statut (`actif` par défaut), catégorie.
+- À la création d'un crédit, une **opération récurrente mensuelle est générée automatiquement** (`Frequence = 3`) et liée via `IDopRecu`.
+- À la suppression, l'opération récurrente associée est supprimée et les opérations passées dissociées (`IDcredit` mis à `null`).
+- Endpoints spécifiques :
+  - `GET /api/credits/{id}/remaining-balance` — calcul du capital restant dû et déjà payé via SQL brut.
+  - `GET /api/credits/{id}/payments` — historique des prélèvements liés.
+- Vue `/credits` : `CreditList` + `CreditCard` (avec barre de progression) + `CreditForm`.
+
+### Biens immobiliers
+- Modèle **Bien** : nom, ville, type, surface, usage (`principale` par défaut), date d'achat, prix nu, frais de notaire, frais d'agence, apport cash, valeur actuelle estimée, lien optionnel vers un crédit (`IDcredit`).
+- CRUD scopé utilisateur ; vérification que le crédit lié appartient bien à l'utilisateur.
+- Vue `/biens` : `BienList` + `BienCard` (résumé investissement / valorisation) + `BienForm`.
+
+### Amortissement
+- Vue `/amortissement` qui filtre les opérations marquées `amortissement = 1` (typiquement le capital remboursé sur les crédits) avec un rendu spécifique.
+
+### Configuration et UX
+- **Thèmes** : clair / sombre / système (composable `useTheme`), persistance `localStorage`, suivi du `prefers-color-scheme`, attribut `data-theme` sur `<html>`.
+- **PWA** : manifeste « MCCB NG », mode `standalone`, service worker `autoUpdate` via `vite-plugin-pwa`.
+- **Mobile** : panneau gauche escamotable au swipe, layout responsive (breakpoint 768 px).
+- **Outils de debug** : intégration optionnelle d'Eruda (panneau dev mobile) chargé à la demande via `useDebugTools` et togglée dans `/config`.
+- Vue `/config` : recharger l'application, éditer le compte, basculer le thème, activer les outils de debug, se déconnecter.
+
+---
+
+## Architecture technique
+
+### Stack
+
+| Couche       | Technologies |
+|--------------|--------------|
+| Frontend     | Vue 3.5, Vue Router 4, Vuex 4, TypeScript 5, Vite 6+, SCSS, Highcharts 12, FontAwesome, `vue3-touch-events`, `vite-plugin-pwa`, `universal-cookie` |
+| Backend      | LoopBack 4 (Node.js ≥ 20, TypeScript 5), `@loopback/authentication-jwt`, Express, MySQL via `loopback-connector-mysql`, `bcryptjs`, `jsonwebtoken` |
+| Base données | MySQL (charset `utf8mb4_unicode_ci`) |
+| Build / déploiement | Docker (multi-stage), nginx (front), `pnpm` workspace |
+
+### Vue d'ensemble
 
 ```
+                     ┌─────────────────────┐
+                     │   Browser / PWA     │
+                     │  (vue3 + vuex)      │
+                     └──────────┬──────────┘
+                                │ Axios, Bearer JWT
+                                ▼
+   ┌──────────────────────────────────────────────────┐
+   │   Vite dev server (port 8080) — proxy /api       │
+   └──────────────────────────────┬───────────────────┘
+                                  ▼
+   ┌──────────────────────────────────────────────────┐
+   │   LoopBack 4 API (Express, port 3000, mount /api)│
+   │   - AuthenticationComponent + JWTAuthn           │
+   │   - REST Explorer  /explorer                     │
+   │   - Custom JwtService (préserve IDuser)          │
+   │   - Controllers : auto-discovery dans dist/      │
+   └──────────────────────────────┬───────────────────┘
+                                  ▼
+                        ┌──────────────────┐
+                        │     MySQL        │
+                        └──────────────────┘
+```
+
+### Architecture backend (`back/`)
+
+Architecture en couches typique LoopBack 4 :
+
+```
+Controllers  →  Repositories  →  DataSource (MySQL)
+     ↑               ↑
+  Services        Models (Entities)
+```
+
+- **`src/index.ts`** crée un `ExpressServer` (`src/server.ts`) qui monte l'application LB4 sur `/api`.
+- **`src/application.ts`** (`ApiLoopbackApplication`) :
+  - Étend `BootMixin(ServiceMixin(RepositoryMixin(RestApplication)))`.
+  - Monte `AuthenticationComponent`, `JWTAuthenticationComponent`, `RestExplorerComponent`.
+  - Surcharge le `TokenService` par défaut par `JwtService` pour propager `IDuser` à travers le token.
+  - `TOKEN_SECRET = generateUniqueId()` — nouveau secret à chaque démarrage (les tokens sont invalides après redémarrage).
+  - Boot auto-discovery des contrôleurs (`./controllers/**/*.controller.js`).
+- **`src/sequence.ts`** : `MySequence extends MiddlewareSequence` (séquence par défaut).
+- **`src/services/`** :
+  - `MyUserService.verifyCredentials({code})` : recherche l'utilisateur par `secret_key` (6 caractères). Le code de `bcryptjs` est en place mais commenté — la connexion par mot de passe n'est pas active.
+  - `JwtService` : signe et vérifie le JWT en y conservant `id`, `name`, `email`, `IDuser`.
+  - `getCurrentUserId(profile)` : utilitaire qui extrait l'`IDuser` numérique du `UserProfile` ; jette `Unauthorized` sinon.
+- **Sécurité par scope** :
+  - **Direct** : `Bien`, `Credit`, `Compte`, `Categorie` portent un champ `IDuser`. Les contrôleurs ajoutent un `where { IDuser }` à toute requête (`scope()` / `assertOwned()`).
+  - **Hérité** : `Operation`, `OperationRecurrente` n'ont pas d'`IDuser`. Les contrôleurs résolvent d'abord la liste des `IDcompte` de l'utilisateur, puis filtrent (`{ IDcompte: { inq: ids } }`).
+- **Migrations** : `src/migrate.ts` (LB4) ; un script SQL ad hoc `migrations/2026-05-02-create-bien.sql` crée la table `Bien`.
+
+### Architecture frontend (`front/`)
+
+```
+src/main.ts          → createApp + register store, router, vue3-touch-events, FontAwesome
+src/App.vue          → layout : AccountHeader (top) + CompteList (gauche) + RouterView + NavBar (bas)
+src/router.ts        → Vue Router en lazy loading, child routes en overlay via RouteOverTheContent
+src/store/index.ts   → Vuex avec 8 modules (sans namespacing)
+src/services/*.ts    → couche API (axios) — un fichier par domaine
+src/composables/     → useTheme, useDebugTools (singletons via useGlobal*)
+src/components/      → cartes / formulaires / listes par domaine
+src/views/           → vues routées
+src/styles/          → variables.scss + theme.css (custom properties) + main.css
+```
+
+**Modules Vuex** (8) : `user`, `compte`, `operation`, `category`, `stats`, `display`, `credit`, `bien`.
+
+**Pattern d'overlay** : les routes enfant (`/newOperation`, `/editCredit/:id`, `/newBien`, etc.) instancient toutes le même composant `RouteOverTheContent` qui rend dynamiquement le formulaire (`operation-form`, `credit-form`, `bien-form`, `transfert-form`, `operation-recurrente-form`, `search`) via la prop `componentName`. Cela évite de gérer un état modal ailleurs.
+
+**Vite / PWA** :
+- Proxy `/api` → `VITE_API_URL` (par défaut `http://localhost:3000`).
+- Manual chunks : `vue` (vue + router + vuex) et `vendor` (axios + highcharts).
+- Service worker auto-update, manifeste `MCCB NG` / `MCCB`, icônes 192/512.
+- Production : image `nginx` avec fallback SPA `try_files $uri /index.html`.
+
+### Flux d'authentification
+
+1. Le front appelle `POST /api/users/login` avec `{ code: "XXXXXX" }`.
+2. `MyUserService.verifyCredentials` recherche l'utilisateur par `secret_key`.
+3. `JwtService.generateToken` signe un JWT avec `{ id, name, email, IDuser }`.
+4. Le front stocke `id` (token) et `userId` (`IDuser`) dans des cookies (`universal-cookie`).
+5. Toute requête authentifiée envoie `Authorization: Bearer <token>`.
+6. Côté serveur, `JwtService.verifyToken` reconstruit le `UserProfile` ; `getCurrentUserId` est utilisé dans chaque contrôleur pour scoper les requêtes à l'utilisateur.
+
+---
+
+## Modèle de données
+
+| Entité | Clé primaire | Champs principaux | Liens |
+|--------|--------------|-------------------|-------|
+| **User** | `id` (UUID) | `IDuser`, `email`, `username`, `secret_key`, `favoris`, `warningTotal`, `warningCompte`, `emailVerified`, `verificationToken` | `hasOne UserCredentials` |
+| **UserCredentials** | `id` (UUID) | `password`, `userId` | `belongsTo User` |
+| **Banque** | `IDbanque` | `NomBanque` | `hasMany Compte` |
+| **Compte** | `IDcompte` | `NomCompte`, `solde` (FLOAT), `IDuser`, `IDbanque`, `bloque`, `joint`, `children`, `retraite`, `porte_feuille`, `visible` | `belongsTo Banque` |
+| **Operation** | `IDop` | `NomOp`, `MontantOp` (FLOAT), `DateOp`, `CheckOp`, `IDcompte`, `IDcat`, `amortissement`, `IDcredit?` | scopée via `Compte` |
+| **OperationRecurrente** | `IDopRecu` | `NomOpRecu`, `MontantOpRecu` (FLOAT), `JourOpRecu`, `JourNumOpRecu`, `MoisOpRecu`, `Frequence` (3=mensuel, 7=annuel), `DernierDateOpRecu`, `IDcompte`, `IDcat`, `IDcredit?` | scopée via `Compte` |
+| **Categorie** | `IDcat` | `Nom`, `IDuser`, `Stats` (bool) | — |
+| **Credit** | `IDcredit` | `NomCredit`, `NomPreteur?`, `MontantInitial` (FLOAT), `MontantMensuel`, `TauxInteret?`, `DateDebut`, `DateFin`, `IDcompte`, `IDopRecu?`, `IDuser`, `Statut` (def `actif`), `IDcat` | — |
+| **Bien** | `IDbien` | `NomBien`, `Ville`, `TypeBien`, `Surface?`, `Usage` (def `principale`), `DateAchat`, `PrixBienNu`, `FraisNotaire`, `FraisAgence`, `ApportCash`, `ValeurActuelle?`, `IDcredit?`, `IDuser` | — |
+| **Stats** | `userID` | (entité support pour les agrégations) | — |
+
+> Les montants financiers utilisent le type SQL `FLOAT`, avec arrondi manuel à 2 décimales côté applicatif.
+
+### Endpoints REST principaux
+
+| Méthode | Route | Description |
+|--------:|-------|-------------|
+| `POST`  | `/api/users/login` | Authentification par `code` (6 car.) — **publique** |
+| `GET`   | `/api/users/whoAmI` | Profil de l'utilisateur courant |
+| `PATCH` | `/api/users/me` | Mise à jour du profil |
+| `GET`   | `/api/users/exists` | Vérifie la validité du token |
+| `POST`  | `/api/signup` | Création d'utilisateur |
+| `GET`   | `/api/ping` | Healthcheck |
+| `*`     | `/api/banques`, `/api/comptes`, `/api/categories` | CRUD scopés utilisateur |
+| `*`     | `/api/operations` | CRUD opérations + endpoints d'analytics |
+| `GET`   | `/api/operations/sumAllCompteForUser` | Totaux pointés / non pointés par compte |
+| `GET`   | `/api/operations/sumForACompte?id=` | Totaux pour un compte |
+| `GET`   | `/api/operations/sumByUserByMonth?monthNumber=&yearNumber=&IDCompte=` | Total dépenses du mois (catégories `Stats=1`) |
+| `GET`   | `/api/operations/sumCategoriesByUserByMonth?monthNumber=&yearNumber=` | Répartition mensuelle par catégorie |
+| `GET`   | `/api/operations/suggestCategories?operationName=&limit=` | Suggestion par similarité de libellé |
+| `*`     | `/api/operation-recurrentes` | CRUD opérations récurrentes |
+| `POST`  | `/api/operation-recurrentes/auto-generation` | Génère les opérations dues |
+| `*`     | `/api/credits` | CRUD crédits (création auto d'une op. récurrente) |
+| `GET`   | `/api/credits/{id}/remaining-balance` | Capital restant dû / payé |
+| `GET`   | `/api/credits/{id}/payments` | Historique de prélèvement |
+| `*`     | `/api/biens` | CRUD biens immobiliers |
+| `GET`   | `/api/stats/evolutionSolde` | Time series `global`, `retraite`, `dispo` |
+
+> L'OpenAPI Explorer est exposé sur `http://localhost:3000/explorer` en local.
+
+---
+
+## Démarrage rapide
+
+### Pré-requis
+- Node.js ≥ 20 (cf. `.nvmrc`)
+- pnpm ≥ 10 (cf. `packageManager` dans `package.json`)
+- MySQL (en local ou via Docker)
+
+### Installation
+
+```bash
+pnpm install                # installe back + front
+```
+
+### Lancer le backend (port 3000)
+
+```bash
+cd back
+cp src/datasources/mccb-mysql.datasource.config.json.example \
+   src/datasources/mccb-mysql.datasource.config.json    # ou créer le fichier (cf. ci-dessous)
+pnpm migrate                # crée / met à jour le schéma MySQL
+pnpm start                  # build + node .
+```
+
+### Lancer le frontend (port 8080)
+
+```bash
+cd front
+echo "VITE_API_URL=http://localhost:3000" > .env
+pnpm dev
+```
+
+### Tests / linting
+
+```bash
+# back
+pnpm --filter @mccbng/back test
+pnpm --filter @mccbng/back lint
+
+# front
+pnpm --filter @mccbng/front test
+pnpm --filter @mccbng/front lint
+pnpm --filter @mccbng/front type-check
+```
+
+---
+
+## Configuration
+
+### Backend (`back/src/datasources/mccb-mysql.datasource.config.json`)
+
+```json
 {
-  "db": {
-    "name": "db",
-    "connector": "memory"
-  },
-  "db_name_connection_mysql": {
-    "host": "localhost",
-    "port": 3306,
-    "database": "database_name",
-    "password": "database_user_password",
-    "name": "db_name_connection_mysql",
-    "user": "database_user_name",
-    "connector": "mysql"
-  },
+  "name": "db_name_connection_mysql",
+  "connector": "mysql",
+  "host": "localhost",
+  "port": 3306,
+  "database": "database_name",
+  "user": "database_user_name",
+  "password": "database_user_password"
 }
 ```
 
-## front
-
-### Config files
-
-- `.env` / `.env.test` / `.env.production`
+### Frontend (`.env` / `.env.test` / `.env.production`)
 
 ```
-VITE_API_URL=http://localhost:3001
+VITE_API_URL=http://localhost:3000
 ```
+
+`VITE_API_URL` sert à la fois pour le proxy Vite en dev et au runtime via `window.env.VITE_API_URL`.
+
+---
+
+## Déploiement Docker
+
+Les deux packages exposent les mêmes scripts pnpm :
+
+```bash
+pnpm --filter @mccbng/back  docker:staging:build && pnpm --filter @mccbng/back  docker:staging:push
+pnpm --filter @mccbng/back  docker:latest:build  && pnpm --filter @mccbng/back  docker:latest:push
+pnpm --filter @mccbng/front docker:staging:build && pnpm --filter @mccbng/front docker:staging:push
+pnpm --filter @mccbng/front docker:latest:build  && pnpm --filter @mccbng/front docker:latest:push
+```
+
+- **Back** : image `node:22-slim`, build TypeScript, suppression de `dist/datasources/*config.json` et de `src/` pour réduire la surface, lance `node .` (port 3000).
+- **Front** : multi-stage `node:22-slim` → `nginx`, sert le dossier `dist/` avec un fallback SPA (`nginx.conf`).
+- Registre : `dockregistry.xju.fr/mccbng/{api,front}:{staging,latest}`.
+
+Un `docker-compose.build.yml` et un script `build-and-push.sh` sont disponibles à la racine pour orchestrer les builds.
+
+---
+
+## Licence
+
+MIT — © Xavier Julien

--- a/back/CLAUDE.md
+++ b/back/CLAUDE.md
@@ -2,19 +2,20 @@
 
 ## Overview
 
-REST API server for the mccbng personal finance application, built with LoopBack 4. Provides JWT-authenticated endpoints for managing bank accounts, transactions, categories, and statistics.
+REST API server for the mccbng personal finance application, built with **LoopBack 4** on top of Express, persisting to **MySQL** via `loopback-connector-mysql`. Provides JWT-authenticated endpoints for managing banks, accounts, transactions, recurring operations, categories, statistics, **loans (Credit)** and **real-estate assets (Bien)**.
 
 ## Commands
 
 ```bash
-yarn build              # Compile TypeScript with lb-tsc
-yarn build:watch        # Watch mode compilation
-yarn start              # Run production server (node -r source-map-support/register .)
-yarn lint               # Run ESLint and Prettier checks
-yarn lint:fix           # Fix linting issues
-yarn test               # Run tests with Mocha (@loopback/testlab)
-yarn clean              # Clean build artifacts (lb-clean dist *.tsbuildinfo .eslintcache)
-yarn migrate            # Run database migrations (auto-builds via premigrate hook)
+pnpm build              # Compile TypeScript with lb-tsc
+pnpm build:watch        # Watch mode compilation
+pnpm start              # Rebuild + run production server (node -r source-map-support/register .)
+pnpm lint               # Run ESLint and Prettier checks
+pnpm lint:fix           # Fix linting issues
+pnpm test               # Run tests with Mocha (@loopback/testlab) — auto-rebuild via pretest
+pnpm clean              # Clean build artifacts (lb-clean dist *.tsbuildinfo .eslintcache)
+pnpm migrate            # Run database migrations (auto-builds via premigrate hook)
+pnpm openapi-spec       # Emit OpenAPI 3 spec into a file
 ```
 
 ## Architecture
@@ -22,18 +23,23 @@ yarn migrate            # Run database migrations (auto-builds via premigrate ho
 ### Application Bootstrap
 
 ```
-src/index.ts                → Entry point, creates ExpressServer
+src/index.ts                → Entry point, instantiates ExpressServer, boot() + start()
 src/server.ts               → ExpressServer wrapping LoopBack app, mounts API at /api
 src/application.ts          → ApiLoopbackApplication (BootMixin + ServiceMixin + RepositoryMixin + RestApplication)
-src/sequence.ts             → MySequence (extends MiddlewareSequence, no custom middleware)
+src/sequence.ts             → MySequence (extends MiddlewareSequence — no custom middleware)
+src/openapi-spec.ts         → CLI to emit the OpenAPI spec
+src/migrate.ts              → CLI for schema migration (--rebuild for DROP/CREATE)
 ```
 
 **Key setup in `application.ts`:**
-- Mounts `AuthenticationComponent` and `JWTAuthenticationComponent`
-- Binds `MyUserService` for custom authentication logic
-- Configures JWT token secret via `generateUniqueId()` (new secret on each restart)
-- Enables REST Explorer at `/explorer`
-- Boot options: auto-discovers controllers in `./controllers`
+
+- Mounts `AuthenticationComponent` and `JWTAuthenticationComponent`.
+- Binds `MyUserService` to `UserServiceBindings.USER_SERVICE` for custom auth logic.
+- **Overrides** `TokenServiceBindings.TOKEN_SERVICE` with the local `JwtService` so that the numeric `IDuser` is preserved in the encoded token (the default LB4 service only carries `id`, `name`, `email`).
+- `TOKEN_SECRET = generateUniqueId()` — a fresh secret per app startup; tokens are invalidated by a restart.
+- Enables REST Explorer at `/explorer`.
+- Boot options auto-discover controllers under `./controllers` (matches `*.controller.js`, `nested: true`).
+- Static file root mapped to `../public`.
 
 ### Layered Architecture
 
@@ -47,138 +53,171 @@ Controllers  →  Repositories  →  DataSource (MySQL)
 
 | Model | Primary Key | Key Properties | Relationships |
 |-------|------------|----------------|---------------|
-| **User** | `id` (UUID) | `IDuser`, `email`, `username`, `secret_key`, `favoris`, `warningTotal`, `warningCompte` | hasOne UserCredentials |
+| **User** | `id` (UUID) | `IDuser` (numeric, used by JWT), `email` (unique), `username`, `secret_key` (6-char login code), `favoris`, `warningTotal`, `warningCompte`, `emailVerified`, `verificationToken` | hasOne UserCredentials |
 | **UserCredentials** | `id` (UUID) | `password`, `userId` | belongsTo User |
 | **Banque** | `IDbanque` (auto-inc) | `NomBanque` | hasMany Compte |
 | **Compte** | `IDcompte` (auto-inc) | `NomCompte`, `solde` (FLOAT), `IDuser`, `IDbanque`, `bloque`, `joint`, `children`, `retraite`, `porte_feuille`, `visible` | belongsTo Banque |
-| **Operation** | `IDop` (auto-inc) | `NomOp`, `MontantOp` (FLOAT), `DateOp`, `CheckOp`, `IDcompte`, `IDcat`, `amortissement` | — |
-| **OperationRecurrente** | `IDopRecu` (auto-inc) | `NomOpRecu`, `MontantOpRecu` (FLOAT), `JourOpRecu`, `JourNumOpRecu`, `MoisOpRecu`, `Frequence` (3=monthly, 7=yearly), `DernierDateOpRecu`, `IDcompte`, `IDcat` | — |
-| **Categorie** | `IDcat` (auto-inc) | `Nom`, `IDuser`, `Stats` (boolean) | — |
-| **Stats** | `userID` | — | — |
+| **Operation** | `IDop` (auto-inc) | `NomOp`, `MontantOp` (FLOAT), `DateOp`, `CheckOp` (def `false`), `IDcompte`, `IDcat` (def `0`), `amortissement` (def `false`), `IDcredit?` | scoped via Compte |
+| **OperationRecurrente** | `IDopRecu` (auto-inc) | `NomOpRecu`, `MontantOpRecu` (FLOAT), `JourOpRecu`, `JourNumOpRecu` (def `1`), `MoisOpRecu` (def `1`), `Frequence` (def `3`: 3=monthly, 7=yearly), `DernierDateOpRecu`, `IDcompte`, `IDcat` (def `0`), `IDcredit?` | scoped via Compte |
+| **Categorie** | `IDcat` (auto-inc) | `Nom`, `IDuser`, `Stats` (bool, def `true`) | — |
+| **Credit** | `IDcredit` (auto-inc) | `NomCredit`, `NomPreteur?`, `MontantInitial` (FLOAT), `MontantMensuel` (FLOAT), `TauxInteret?` (FLOAT), `DateDebut`, `DateFin`, `IDcompte`, `IDopRecu?`, `IDuser`, `Statut` (def `'actif'`), `IDcat` (def `0`) | — |
+| **Bien** | `IDbien` (auto-inc) | `NomBien`, `Ville`, `TypeBien`, `Surface?` (FLOAT), `Usage` (def `'principale'`), `DateAchat`, `PrixBienNu` (FLOAT), `FraisNotaire` (FLOAT), `FraisAgence?` (FLOAT, def `0`), `ApportCash?` (FLOAT, def `0`), `ValeurActuelle?` (FLOAT), `IDcredit?`, `IDuser` | — |
+| **Stats** | `userID` | — | view-like model used by analytics |
+
+> Monetary values are stored as MySQL `FLOAT`. Always round amounts to 2 decimals at the application boundary.
 
 ### Controllers (`src/controllers/`)
 
-All controllers except `PingController` and `UserController.login` require `@authenticate('jwt')`.
+All controllers except the public `POST /users/login`, `POST /signup`, and `GET /ping` are decorated with `@authenticate('jwt')`. Every protected handler resolves the user via `getCurrentUserId(currentUserProfile)` and then enforces ownership through one of two patterns:
 
-| Controller | Key Endpoints | Description |
-|-----------|--------------|-------------|
-| **UserController** | `POST /users/login`, `GET /users/whoAmI`, `GET /users/exists`, `POST /signup` | Authentication and user management. Login uses 6-char `code` (secret_key) |
-| **PingController** | `GET /ping` | Health check |
-| **BanqueController** | CRUD `/banques` | Bank management |
-| **CompteController** | CRUD `/comptes` | Account management |
-| **CompteBanqueController** | `GET /comptes/{id}/banque` | Get bank for an account |
-| **OperationController** | CRUD `/operations` + analytics endpoints | Transaction management |
-| **OperationRecurrenteController** | CRUD `/operation-recurrentes`, `POST /operation-recurrentes/auto-generation/{userID}` | Recurring operations with auto-generation |
-| **CategoriesController** | CRUD `/categories` | Category management |
-| **StatsController** | `GET /stats/evolutionSolde/{userID}` | Balance evolution (global, retraite, dispo) |
+- **Direct scoping** (`scope()`/`assertOwned()`) when the entity has an `IDuser` column.
+- **Inherited scoping** when ownership comes from the parent `Compte`: the controller resolves the user's `IDcompte[]` and constrains queries with `{ IDcompte: { inq: ids } }` (see `OperationController.userCompteIds` and `OperationRecurrenteController`).
 
-**Notable OperationController endpoints:**
-- `GET /operations/sumAllCompteForUser?userID=` — Sum checked/unchecked totals by account
-- `GET /operations/sumForACompte?id=` — Sum for a specific account
-- `GET /operations/sumByUserByMonth?userID=&monthNumber=&yearNumber=&IDCompte=` — Monthly sums by category
-- `GET /operations/sumCategoriesByUserByMonth?userID=&monthNumber=&yearNumber=` — Category totals for a month
-- `GET /operations/suggestCategories?operationName=&limit=` — Smart category suggestions based on name pattern matching
+| Controller | Route prefix | Notable endpoints |
+|-----------|--------------|-------------------|
+| **PingController** | `/ping` | `GET /ping` — health check, public |
+| **UserController** | `/users` + `/signup` | `POST /users/login` (public, body `{code: "XXXXXX"}` → `{id, userId}`); `GET /users/whoAmI`; `PATCH /users/me` (email / username / warningTotal / warningCompte / favoris, with email-uniqueness check); `GET /users/exists`; `POST /signup` (creates User + bcrypt-hashed UserCredentials, with uniqueness checks on `email`, `secret_key`, `IDuser`) |
+| **BanqueController** | `/banques` | Standard CRUD |
+| **CompteController** | `/comptes` | CRUD scoped per user |
+| **CompteBanqueController** | `/comptes/{id}/banque` | Returns the bank for a given account |
+| **CategoriesController** | `/categories` | CRUD scoped per user |
+| **OperationController** | `/operations` | CRUD + analytics (see below) |
+| **OperationRecurrenteController** | `/operation-recurrentes` | CRUD + `POST /operation-recurrentes/auto-generation` (replays missed occurrences for the current user) |
+| **CreditController** | `/credits` | CRUD; on create auto-spawns a monthly OperationRecurrente; on delete removes the OperationRecurrente and nulls `IDcredit` on past Operations. Plus `GET /credits/{id}/remaining-balance` and `GET /credits/{id}/payments` |
+| **BienController** | `/biens` | CRUD scoped per user; validates that any linked `IDcredit` belongs to the same user |
+| **StatsController** | `/stats` | `GET /stats/evolutionSolde` returns `{soldeGlobal, soldeRetraite, soldeDispo, global, retraite, dispo}` time series |
+
+**Notable `OperationController` analytics endpoints:**
+
+- `GET /operations/sumAllCompteForUser` — checked / unchecked totals grouped by account.
+- `GET /operations/sumForACompte?id=<IDcompte>` — checked / unchecked totals for a single account.
+- `GET /operations/sumByUserByMonth?monthNumber=&yearNumber=&IDCompte=` — monthly total restricted to categories with `Stats=1`.
+- `GET /operations/sumCategoriesByUserByMonth?monthNumber=&yearNumber=` — per-category totals for a month.
+- `GET /operations/suggestCategories?operationName=&limit=` — category suggestions ranked by frequency of past operations whose name matches (LIKE), defaults to 5, clamped 1-50, name min length 2.
 
 ### Repositories (`src/repositories/`)
 
-Standard `DefaultCrudRepository` implementations for each model. Notable custom logic:
+Most repositories are vanilla `DefaultCrudRepository`. Custom logic worth knowing:
 
-- **UserRepository**: `findCredentials(userId)` method, hasOne relationship with UserCredentials
-- **CompteRepository**: belongsTo accessor for Banque with inclusion resolver
-- **StatsRepository**: `evolutionSolde(userID)` — Executes raw SQL to compute balance evolution across account types (global, retraite, dispo) grouped by date
+- **UserRepository** — declares the hasOne relation with `UserCredentials` and exposes `findCredentials(userId)`.
+- **CompteRepository** — declares belongsTo Banque with an inclusion resolver.
+- **StatsRepository** — implements `evolutionSolde(userID)`. Runs raw SQL (`repository.execute(...)`) using MySQL `DATE_FORMAT` to compute current balances and daily time series across three account groupings (global, retraite, dispo / disponible).
+- **OperationRepository** / **OperationRecurrenteRepository** — used together with `repository.execute(...)` for the analytics SQL.
 
 ### Services (`src/services/`)
 
-- **MyUserService** (`user.service.ts`): Custom authentication service
-  - `verifyCredentials(credentials)` — Validates `code` field (6-char secret_key lookup)
-  - `convertToUserProfile(user)` — Builds UserProfile with securityId
-  - `findUserById(id)` — Finds user by UUID
-- **Binding keys** (`keys.ts`): `USER_SERVICE`, `USER_REPOSITORY`, `USER_CREDENTIALS_REPOSITORY`
+- **`MyUserService`** (`user.service.ts`)
+  - `verifyCredentials({code})` — looks up user by `secret_key`. The bcrypt password block is intentionally commented out: login is currently a 6-char secret-key lookup only.
+  - `convertToUserProfile(user)` — builds a UserProfile with `securityId = id`, plus `name`, `id`, `email`, `IDuser`.
+  - `findUserById(id)` — finds the user by UUID.
+- **`JwtService`** (`jwt.service.ts`) — overrides the default LB4 token service so that `IDuser` (numeric) is preserved across encode/decode. Uses `jsonwebtoken` directly with `TOKEN_SECRET` and `TOKEN_EXPIRES_IN`.
+- **`getCurrentUserId(profile)`** (`current-user.ts`) — utility used by every protected controller; throws `Unauthorized` when the profile lacks a numeric `IDuser`.
+- **Binding keys** (`keys.ts`): `UserServiceBindings.USER_SERVICE`, `USER_REPOSITORY`, `USER_CREDENTIALS_REPOSITORY`.
 
 ### DataSource (`src/datasources/`)
 
-- **MccbMysqlDataSource**: MySQL connection via `loopback-connector-mysql`
-- Config file: `mccb-mysql.datasource.config.json` (host, port, user, password, database)
-- Implements `LifeCycleObserver` for graceful shutdown
+- **MccbMysqlDataSource** — MySQL connection via `loopback-connector-mysql`.
+- Config loaded from `mccb-mysql.datasource.config.json` (host, port, user, password, database). This file is `.gitignored` per package and removed from the Docker image.
+- Implements `LifeCycleObserver` for graceful shutdown.
 
 ### Authentication Flow
 
-1. Client sends `POST /api/users/login` with `{ code: "XXXXXX" }` (6 chars)
-2. `MyUserService.verifyCredentials()` looks up user by `secret_key`
-3. JWT token generated using `TokenService` with app-specific secret
-4. Token returned as `{ id: token, userId: IDuser }`
-5. Protected endpoints require `Authorization: Bearer <token>` header
+1. Client sends `POST /api/users/login` with `{ code: "XXXXXX" }` (6 chars).
+2. `MyUserService.verifyCredentials()` looks up the user by `secret_key`.
+3. JWT is generated by the local `JwtService` with payload `{ id, name, email, IDuser }`.
+4. Response: `{ id: <token>, userId: <IDuser> }`.
+5. Protected endpoints expect `Authorization: Bearer <token>`. The decoded profile carries `IDuser`, which is read by every controller via `getCurrentUserId()`.
+
+> The `TOKEN_SECRET` is regenerated on every backend startup; existing tokens become invalid. There is no refresh-token mechanism.
 
 ### Database Migrations
 
-`src/migrate.ts` — CLI script for schema management:
-- Default: `ALTER` existing schema to match models
-- `--rebuild` flag: `DROP` and recreate schema
-- Auto-builds TypeScript before running (via `premigrate` npm hook)
+- `src/migrate.ts` — LoopBack CLI script:
+  - Default: `ALTER` existing schema to match models.
+  - `--rebuild` flag: `DROP` and recreate schema.
+  - `pnpm migrate` auto-builds TypeScript first via the `premigrate` hook.
+- `migrations/2026-05-02-create-bien.sql` — ad hoc SQL migration that creates the `Bien` table (charset `utf8mb4_unicode_ci`, indexes on `IDuser` and `IDcredit`, no FK constraints).
+
+## Testing
+
+- Mocha + `@loopback/testlab`.
+- Test config: `.mocharc.json`. Tests live in `src/__tests__/` and run from `dist/__tests__/` after `pretest` rebuild.
+- Acceptance tests under `__tests__/acceptance/` (see `ping.controller.acceptance.ts`, `test-helper.ts`).
 
 ## Dependencies
 
 ### Runtime
-- `@loopback/boot`, `@loopback/core`, `@loopback/repository`, `@loopback/rest` — LoopBack 4 framework
-- `@loopback/authentication`, `@loopback/authentication-jwt` — JWT auth
-- `@loopback/rest-explorer` — OpenAPI Explorer
-- `loopback-connector-mysql` — MySQL connector
-- `express`, `cors`, `compression` — HTTP server
-- `bcryptjs` — Password hashing (available but currently not used for login)
-- `tslib` — TypeScript runtime helpers
+
+- `@loopback/boot`, `@loopback/core`, `@loopback/repository`, `@loopback/rest`, `@loopback/service-proxy` — framework v8/v15
+- `@loopback/authentication` ^12, `@loopback/authentication-jwt` ^0.16 — JWT auth
+- `@loopback/rest-explorer` ^8 — Swagger / OpenAPI Explorer at `/explorer`
+- `loopback-connector-mysql` ^8 — MySQL connector
+- `express`, `cors`, `compression` — HTTP server stack
+- `tslib` — TypeScript helpers
+- `bcryptjs`, `jsonwebtoken`, `lodash` (transitive via auth packages and used in `user.controller.ts` / `jwt.service.ts`)
 
 ### Dev
+
 - TypeScript ~5.2, ESLint ^8.57
-- `@loopback/build`, `@loopback/testlab` — Build and test tooling
-- Mocha for testing
+- `@loopback/build`, `@loopback/testlab`, `@loopback/eslint-config`
+- Mocha for testing, `source-map-support` for stack traces
 
 ## Docker
 
-- **Base**: `node:22-slim`
-- **Build**: Copies source, installs deps, compiles TypeScript
-- **Security**: Removes `dist/datasources/*config.json` and `src/*` from image
-- **Runtime**: `HOST=0.0.0.0 PORT=3000`, command `node .`
-- **Registry**: `dockregistry.xju.fr/mccbng/api:{staging,latest}`
+- **Base**: `node:22-slim`.
+- **Build**: copies source, installs deps with pnpm, runs `lb-tsc`.
+- **Hardening**: removes `dist/datasources/*config.json` and `src/*` from the final image.
+- **Runtime**: `HOST=0.0.0.0 PORT=3000`, command `node .`.
+- **Registry**: `dockregistry.xju.fr/mccbng/api:{staging,latest}`.
+- See `package.json` scripts `docker:staging:*`, `docker:latest:*`, `docker:run`, `docker:inspect`, `docker:stop`.
 
 ## File Structure
 
 ```
 back/
 ├── src/
-│   ├── index.ts                    # Entry point
-│   ├── server.ts                   # ExpressServer wrapper
-│   ├── application.ts              # LoopBack application config
-│   ├── sequence.ts                 # Request sequence (MiddlewareSequence)
-│   ├── migrate.ts                  # Database migration script
+│   ├── index.ts                        # Entry point
+│   ├── server.ts                       # ExpressServer wrapper (mounts /api)
+│   ├── application.ts                  # LoopBack application config + JwtService binding
+│   ├── sequence.ts                     # MiddlewareSequence (default)
+│   ├── migrate.ts                      # Schema migration CLI
+│   ├── openapi-spec.ts                 # OpenAPI emitter
 │   ├── controllers/
-│   │   ├── user.controller.ts      # Auth + user management
-│   │   ├── ping.controller.ts      # Health check
-│   │   ├── banque.controller.ts    # Bank CRUD
-│   │   ├── compte.controller.ts    # Account CRUD
-│   │   ├── compte-banque.controller.ts  # Account-Bank relation
-│   │   ├── operation.controller.ts      # Transaction CRUD + analytics
-│   │   ├── operation-recurrente.controller.ts  # Recurring ops + auto-gen
-│   │   ├── categories.controller.ts     # Category CRUD
-│   │   └── stats.controller.ts          # Balance evolution
-│   ├── models/
-│   │   ├── user.model.ts
-│   │   ├── user-credentials.model.ts
-│   │   ├── banque.model.ts
-│   │   ├── compte.model.ts
-│   │   ├── operation.model.ts
-│   │   ├── operation-recurrente.model.ts
-│   │   ├── categorie.model.ts
-│   │   └── stats.model.ts
-│   ├── repositories/               # DefaultCrudRepository per model
+│   │   ├── user.controller.ts          # login / whoAmI / updateMe / exists / signup
+│   │   ├── ping.controller.ts          # health check
+│   │   ├── banque.controller.ts        # bank CRUD
+│   │   ├── compte.controller.ts        # account CRUD (user-scoped)
+│   │   ├── compte-banque.controller.ts # account → bank relation
+│   │   ├── operation.controller.ts     # transaction CRUD + analytics
+│   │   ├── operation-recurrente.controller.ts # recurring ops + auto-generation
+│   │   ├── categories.controller.ts    # category CRUD
+│   │   ├── credit.controller.ts        # loan CRUD + remaining-balance + payments
+│   │   ├── bien.controller.ts          # real-estate asset CRUD
+│   │   └── stats.controller.ts         # balance evolution
+│   ├── models/                         # one file per entity (User, Banque, Compte, Operation, OperationRecurrente, Categorie, Credit, Bien, Stats, UserCredentials)
+│   ├── repositories/                   # DefaultCrudRepository per model + custom evolutionSolde in stats.repository.ts
 │   ├── services/
-│   │   ├── user.service.ts         # MyUserService (auth logic)
-│   │   ├── keys.ts                 # DI binding keys
+│   │   ├── user.service.ts             # MyUserService
+│   │   ├── jwt.service.ts              # Custom token service (preserves IDuser)
+│   │   ├── current-user.ts             # getCurrentUserId helper
+│   │   ├── keys.ts                     # DI binding keys
 │   │   └── interfaces/
-│   │       └── user.service.ts     # UserService interface
+│   │       └── user.service.ts
 │   └── datasources/
 │       ├── mccb-mysql.datasource.ts
-│       └── mccb-mysql.datasource.config.json
+│       └── mccb-mysql.datasource.config.json (gitignored)
+├── migrations/
+│   └── 2026-05-02-create-bien.sql
+├── __tests__/                          # acceptance tests (built into dist/__tests__)
+├── public/                             # static root
 ├── Dockerfile
 ├── package.json
 └── tsconfig.json
 ```
+
+## Conventions When Editing
+
+- New endpoint: decorate with `@authenticate('jwt')`, inject `@inject(SecurityBindings.USER) currentUserProfile: UserProfile`, call `getCurrentUserId(currentUserProfile)`, then either `scope()` or `assertOwned()` before any DB read/write.
+- Cascading writes (e.g. creating a Credit creates an OperationRecurrente; deleting it removes that record and nulls back-references on `Operation`) should stay in the controller — there is no service layer for cross-entity orchestration.
+- Avoid adding `IDuser` columns to entities that are already scoped via a parent (`Operation`, `OperationRecurrente`); follow the `userCompteIds` pattern instead.
+- When introducing custom analytics, prefer parameterized `repository.execute(sql, params)` to keep the SQL injection surface small.

--- a/front/CLAUDE.md
+++ b/front/CLAUDE.md
@@ -2,21 +2,21 @@
 
 ## Overview
 
-Single Page Application for the mccbng personal finance application. Built with Vue 3, TypeScript, Vite, and Vuex 4. Provides a mobile-responsive PWA for managing bank accounts, transactions, categories, and statistics with dark/light theme support and touch gestures.
+Single Page Application for the mccbng personal finance app. Built with **Vue 3.5 + TypeScript + Vite + Vuex 4 + Vue Router 4**, with light/dark theme support, touch gestures, and PWA packaging. Covers banks, accounts, operations, recurring operations, categories, statistics, **loans (Credit)** and **real-estate assets (Bien)**.
 
 ## Commands
 
 ```bash
-yarn dev                # Development server with Vite (port 8080, proxies /api to backend)
-yarn build              # Production build (output: dist/)
-yarn build:staging      # Staging build (--mode test)
-yarn test               # Run Jest tests
-yarn test:unit          # Unit tests only
-yarn test:watch         # Tests in watch mode
-yarn test:coverage      # Tests with coverage report
-yarn type-check         # TypeScript type checking (vue-tsc --noEmit)
-yarn lint               # ESLint with auto-fix (.vue, .js, .jsx, .ts, .tsx)
-yarn lint:check         # ESLint check only (no auto-fix)
+pnpm dev                # Vite dev server (port 8080, proxies /api to backend)
+pnpm build              # Production build (dist/)
+pnpm build:staging      # Staging build (--mode test)
+pnpm test               # Run Jest tests
+pnpm test:unit          # Unit tests only
+pnpm test:watch         # Tests in watch mode
+pnpm test:coverage      # Tests with coverage report
+pnpm type-check         # TypeScript type checking (vue-tsc --noEmit)
+pnpm lint               # ESLint with auto-fix (.vue, .js, .jsx, .ts, .tsx)
+pnpm lint:check         # ESLint check only
 ```
 
 ## Architecture
@@ -24,290 +24,338 @@ yarn lint:check         # ESLint check only (no auto-fix)
 ### Application Bootstrap
 
 ```
-src/main.ts             → Creates Vue app, registers plugins (store, router, Vue2TouchEvents, FontAwesome)
-src/App.vue             → Root component with layout: AccountHeader + CompteList (left panel) + RouterView (right panel) + NavBar
-src/router.ts           → Vue Router with lazy-loaded routes
-src/store/index.ts      → Vuex store with 6 modules
+src/main.ts             → Creates Vue app, registers store, router, vue3-touch-events, FontAwesome
+src/App.vue             → Root layout: AccountHeader (top) + CompteList (left) + RouterView + NavBar (bottom)
+src/router.ts           → Vue Router 4 with lazy-loaded routes
+src/store/index.ts      → Vuex 4 store with 8 modules (no namespacing)
 ```
 
-**Plugin registration order in `main.ts`:**
+**Plugin registration order (`main.ts`):**
+
 1. Vuex store
 2. Vue Router
-3. Vue2TouchEvents (custom touch events plugin from `vue-touch-events/` workspace)
-4. FontAwesome (registered as global `FontAwesomeIcon` component)
+3. `vue3-touch-events` (npm package — replaces the former local `vue-touch-events/` workspace)
+4. FontAwesome (registered globally as `<FontAwesomeIcon>` via `plugins/fontawesome.ts`)
 
-### Layout Architecture
+`App.vue` calls `useGlobalTheme()` and `useGlobalDebugTools().initDebugTools()` on setup, watches `store.state.user.id` to fetch the account list and categories on login, and force-pushes `/login` on init.
+
+### Layout
 
 ```
-┌─────────────────────────────────────────────┐
-│              AccountHeader                   │  ← Shows active account name, balances, totals
-├──────────────┬──────────────────────────────┤
-│              │                              │
-│  CompteList  │        RouterView            │  ← Main content area
-│  (left panel)│    (Home / Stats / etc.)     │
-│              │                              │
-│  Swipeable   │        Swipeable             │
-│  ←close      │        →open                 │
-│              │                              │
-├──────────────┴──────────────────────────────┤
-│                NavBar                        │  ← Bottom navigation
-└─────────────────────────────────────────────┘
+┌──────────────────────────────────────────────┐
+│              AccountHeader                    │  ← active account, balances, totals, mask toggle
+├──────────────┬───────────────────────────────┤
+│  CompteList  │        RouterView              │
+│  (left)      │      (Home / Stats / …)        │
+│              │                                │
+│  swipe ←     │        swipe →                 │
+│  closes      │        opens left panel        │
+├──────────────┴───────────────────────────────┤
+│                NavBar                          │  ← bottom nav
+└──────────────────────────────────────────────┘
 ```
 
-- **Desktop** (>=768px): Left panel visible at 33% width, right panel takes remaining space
-- **Mobile** (<768px): Left panel slides in/out with CSS transitions and swipe gestures, full-width when visible
+- **Desktop** (≥ 768 px): left panel always visible at 33 % width, right panel takes the rest.
+- **Mobile** (< 768 px): left panel slides in/out with CSS transitions and swipe gestures, full-width when open.
 
 ### Routes (`src/router.ts`)
 
-All routes use lazy loading via dynamic `import()`:
+All routes use lazy loading via `import()` with `webpackChunkName` hints. Child routes use the **overlay pattern**: every child path renders the same `RouteOverTheContent` view, which in turn renders a form (`OperationForm`, `TransfertForm`, `Search`, `OperationRecurrenteForm`, `CreditForm`, `BienForm`) based on the `componentName` prop.
 
-| Path | View | Description | Children |
-|------|------|-------------|----------|
-| `/` | `Home` | Main operations view | `/newOperation`, `/editOperation/:id`, `/search`, `/transfert`, `/retrait` |
-| `/recurrOperation` | `OperationsRecurrentes` | Recurring operations list | `/newRecurrOperation`, `/editRecurrOperation/:id` |
-| `/amortissement` | `Amortissement` | Amortization tracking | — |
-| `/stats` | `Stats` | Statistics dashboard | — |
-| `/login` | `Login` | Authentication page | — |
-| `/config` | `Config` | User settings | — |
+| Path | View | Chunk | Children |
+|------|------|-------|----------|
+| `/` | `Home` | `home` | `/newOperation`, `/editOperation/:id`, `/search`, `/transfert`, `/retrait` |
+| `/recurrOperation` | `OperationsRecurrentes` | `operecur` | `/newRecurrOperation`, `/editRecurrOperation/:id` |
+| `/amortissement` | `Amortissement` | `operecur` | — |
+| `/credits` | `Credits` | `credits` | `/newCredit`, `/editCredit/:id` |
+| `/biens` | `Biens` | `biens` | `/newBien`, `/editBien/:id` |
+| `/stats` | `Stats` | `stats` | — |
+| `/login` | `Login` | `login` | — |
+| `/config` | `Config` | `config` | — |
+| `/editUser` | `EditUser` | `edituser` | — |
 
-Child routes use `RouteOverTheContent` — a wrapper view that dynamically renders `OperationForm`, `Search`, `TransfertForm`, or `OperationRecurrenteForm` based on `componentName` prop. This creates a modal-like overlay pattern.
-
-Routes with `meta.disabledTotalHeader: true` hide the total balance in the header.
+Routes with `meta.disabledTotalHeader: true` hide the global totals in `AccountHeader`.
 
 ### Vuex Store (`src/store/`)
 
-6 modules, all without namespacing:
+Eight modules, no namespacing — accessed as `store.state.<module>.<prop>` and via root-level dispatch.
 
-#### `user` module
-- **State**: `id`, `favoris`, `warningTotal`, `token`, `maskAmount`
-- **Actions**: `fetchUser(userID)`, `saveUserToken(token)`, `toggleMaskAmount()`
-- **Note**: `maskAmount` hides monetary values in the UI
+#### `user`
+- **State**: `id`, `username`, `email`, `token`, `favoris`, `warningTotal`, `warningCompte`, `maskAmount`
+- **Actions**: `fetchUser(userID)`, `updateUser(updates)`, `saveUserToken(token)`, `toggleMaskAmount()`
+- `maskAmount` hides monetary values throughout the UI.
 
-#### `compte` module
-- **State**: `activeAccount`, `accountList`, `currency` (default: `'€'`)
+#### `compte`
+- **State**: `activeAccount`, `accountList`, `currency` (default `'€'`)
 - **Getters**: `bloquedCompte`, `retraiteCompte`, `availableCompte`, `porteFeuilleCompte`, `jointCompte`, `childrenCompte`, `totalAvailable`, `totalGlobal`, `totalRetraite`, `totalJoint`, `totalChildren`, `getAccount(IDcompte)`, `visibleAccounts`
 - **Actions**: `fetchUserByIDAndGenerateRecurringOp(userID)`, `generateRecurringOperations()`, `fetchActiveAccount(accountID)`, `fetchAccountList()`
-- **Logic**: Computes checked/unchecked balances per account, filters by account type flags
+- Computes checked / unchecked balances per account; filters by account-type flags.
 
-#### `operation` module
+#### `operation`
 - **State**: `operationsOfActiveAccount`, `recurringOperations`, `hasMoreOperations`, `isLoadingOperations`, `operationsSkip`, `operationsLimit` (35), `isSearchMode`, `currentSearchTerms`
-- **Actions**: `fetchOperationsOfActiveAccount()`, `loadMoreOperations()` (infinite scroll), `updateOperation(op)`, `deleteOperation(op)`, `createTransfert(op)` (creates debit+credit pair), `fetchRecurrOperation()`, `updateRecurringOperation(op)`, `deleteRecurringOperation(op)`, `getSearchOperations(terms)`, `loadMoreSearchOperations()`, `fetchOperations(where)`
-- **Pagination**: Skip/limit based with 35 items per page
+- **Actions**: `fetchOperationsOfActiveAccount()`, `loadMoreOperations()` (infinite scroll), `updateOperation(op)`, `deleteOperation(op)`, `createTransfert(op)` (creates a debit + credit pair), `fetchRecurrOperation()`, `updateRecurringOperation(op)`, `deleteRecurringOperation(op)`, `getSearchOperations(terms)`, `loadMoreSearchOperations()`, `fetchOperations(where)`
+- Skip/limit pagination, 35 items per page.
 
-#### `category` module
+#### `category`
 - **State**: `list`
-- **Getters**: `getCategoryName(IDcat)` — Finds category by ID
-- **Actions**: `fetchCategoryList()` — Lazy-loads (only fetches if < 2 items)
+- **Getters**: `getCategoryName(IDcat)`
+- **Actions**: `fetchCategoryList()` — lazy loads (only fetches if list is empty / very small).
 
-#### `stats` module
+#### `stats`
 - **State**: `negativeMonth`, `currentMonth`, `currentYear`, `categoriesTotal`
-- **Getters**: `getCategoriesTotalForHighchartPie` — Transforms categories data for Highcharts pie chart format
+- **Getters**: `getCategoriesTotalForHighchartPie` (transforms data for Highcharts pie format)
 - **Actions**: `fetchSumByUserByMonth()`, `fetchSumCategoriesByUserByMonth()`, `changeStatsCurrentYear(year)`, `changeStatsCurrentMonth(month)`
 
-#### `display` module
-- **State**: `account_list` (boolean, toggles left panel visibility)
+#### `display`
+- **State**: `account_list` (boolean, toggles left panel visibility on mobile)
 - **Actions**: `toggleAccountList(force?)`
+
+#### `credit`
+- **State**: `creditList`, `activeCredit`, `creditBalances` (dict by `IDcredit`), `isLoadingCredits`
+- **Getters**: `creditFromList(creditID)`
+- **Actions**: `fetchCredits()` (also fetches remaining balances for each), `updateCredit(credit)`, `deleteCredit(credit)`, `fetchCreditDetails(IDcredit)`
+
+#### `bien`
+- **State**: `bienList`, `activeBien`, `isLoadingBiens`
+- **Getters**: `bienFromList(bienID)`
+- **Actions**: `fetchBiens()`, `updateBien(bien)`, `deleteBien(bien)`, `fetchBienDetails(IDbien)`
 
 ### Services (`src/services/`)
 
-API communication layer using Axios. All services accept `token` and `apiUrl` parameters.
+API layer using Axios. Each function accepts `token` and `apiUrl` so services stay stateless.
 
 | Service | Functions | API Endpoints |
 |---------|-----------|---------------|
 | **auth.ts** | `auth(code, apiUrl)`, `saveCookies()`, `removeCookies()`, `getTokenCookie()`, `getUserIDCookie()`, `checkUserAuthentification()` | `POST /api/users/login`, `GET /api/users/exists` |
-| **user.ts** | `fetchUser(userID, token, apiUrl)` | `GET /api/users/whoAmI` |
+| **user.ts** | `fetchUser(userID, token, apiUrl)`, `updateUser(updates, token, apiUrl)` | `GET /api/users/whoAmI`, `PATCH /api/users/me` |
 | **compte.ts** | `fetchAccountList()`, `sumAllCompteForUser()`, `sumForACompte()` | `GET /api/comptes`, `GET /api/operations/sumAllCompteForUser`, `GET /api/operations/sumForACompte` |
-| **operation.ts** | `fetchOperationsForAccount()`, `updateOperation()`, `deleteOperation()`, `fetchRecurrOperation()`, `updateRecurringOperation()`, `deleteRecurringOperation()`, `generateRecurringOperations()`, `fetchSearchOperations()`, `fetchOperations()` | Various `/api/operations` and `/api/operation-recurrentes` endpoints |
+| **operation.ts** | `fetchOperationsForAccount()`, `updateOperation()`, `deleteOperation()`, `createTransfert()`, `fetchRecurrOperation()`, `updateRecurringOperation()`, `deleteRecurringOperation()`, `generateRecurringOperations()`, `fetchSearchOperations()`, `fetchOperations(where)` | various `/api/operations` and `/api/operation-recurrentes` endpoints |
 | **category.ts** | `fetchCategoryList()` | `GET /api/categories` |
-| **stats.ts** | `fetchEvolutionSolde()` | `GET /api/stats/evolutionSolde` |
+| **stats.ts** | `fetchEvolutionSolde()`, `fetchSumByUserByMonth()`, `fetchSumCategoriesByUserByMonth()` | `GET /api/stats/evolutionSolde`, `/api/operations/sumByUserByMonth`, `/api/operations/sumCategoriesByUserByMonth` |
+| **credit.ts** | `fetchCredits()`, `fetchCreditById()`, `updateCredit()`, `deleteCredit()`, `fetchCreditRemainingBalance()`, `fetchCreditPayments()` | `GET/POST /api/credits`, `GET/PUT/DEL /api/credits/:id`, `GET /api/credits/:id/remaining-balance`, `GET /api/credits/:id/payments` |
+| **bien.ts** | `fetchBiens()`, `fetchBienById()`, `updateBien()`, `deleteBien()` | `GET/POST /api/biens`, `GET/PUT/DEL /api/biens/:id` |
 
-**Authentication**: Token stored in cookies (`userToken`, `userID`) via `universal-cookie`. The app redirects to `/login` on startup and checks token validity.
+**Authentication**: token stored in cookies (`userToken`, `userID`) via `universal-cookie`. The app force-pushes to `/login` on startup; `Login.vue` validates the 6-char code, stores the cookies, then routes to `/`.
 
 ### Components (`src/components/`)
 
+#### Layout / navigation
+
 | Component | Description |
 |-----------|-------------|
-| **AccountHeader.vue** | Top header showing active account name, checked/unchecked balances, and global totals |
+| **AccountHeader.vue** | Top header: active account name, checked / unchecked balances, global totals, mask toggle |
 | **NavBar.vue** | Bottom navigation bar with links to main views |
-| **CompteList/index.vue** | Left panel account list, grouped by account type |
-| **CompteList/Compte.vue** | Individual account item in the list |
-| **OperationList.vue** | Scrollable list of operations for the active account with infinite scroll |
-| **Home/Operation.vue** | Single operation row with swipe-to-delete and check/uncheck |
-| **OperationForm.vue** | Form for creating/editing operations with category suggestion |
-| **TransfertForm.vue** | Form for transfers between accounts (debit + credit) |
-| **Search.vue** | Search form to find operations by name across all accounts |
-| **OperationRecurrenteList.vue** | List of recurring operations |
-| **OperationRecurrente.vue** | Single recurring operation row |
-| **OperationRecurrenteForm.vue** | Form for creating/editing recurring operations |
-| **Currency.vue** | Currency display component (formats amounts with `€`) |
-| **Amortissement/Operation.vue** | Operation row for amortization view |
-| **Stats/SumByMonth.vue** | Monthly expense summary component |
-| **Stats/PieByCategorie.vue** | Highcharts pie chart for category breakdown |
-| **Stats/TimeSeriesEvolutionSoldes.vue** | Highcharts time series for balance evolution |
+| **CompteList/index.vue** | Left panel — accounts grouped by type |
+| **CompteList/Compte.vue** | Single account list item |
+
+#### Operations
+
+| Component | Description |
+|-----------|-------------|
+| **OperationList.vue** | Scrollable list with infinite scroll, loading and empty states |
+| **Home/Operation.vue** | Single operation row — swipe-to-delete, click-to-edit, check/uncheck toggle |
+| **Amortissement/Operation.vue** | Operation row with amortization-specific rendering |
+| **OperationForm.vue** | Create/edit form, includes category suggestion via `suggestCategories` |
+| **TransfertForm.vue** | Account-to-account transfer (creates the debit + credit pair) |
+| **Search.vue** | Cross-account search by operation name |
+
+#### Recurring operations
+
+| Component | Description |
+|-----------|-------------|
+| **OperationRecurrenteList.vue** | List container |
+| **OperationRecurrente.vue** | Single recurring-operation row |
+| **OperationRecurrenteForm.vue** | Create/edit form |
+
+#### Credits (loans)
+
+| Component | Description |
+|-----------|-------------|
+| **CreditList.vue** | List container with loading / empty states |
+| **CreditCard.vue** | Card showing name, lender, initial / monthly amount, remaining balance with progress bar, interest rate |
+| **CreditForm.vue** | Form with name, lender, initial amount, interest rate, monthly payment, status, dates, linked account |
+
+#### Biens (real-estate assets)
+
+| Component | Description |
+|-----------|-------------|
+| **BienList.vue** | List container |
+| **BienCard.vue** | Card showing name, type, city, surface, purchase date, total invested, current valuation |
+| **BienForm.vue** | Form with name, city, type, usage, surface, purchase date, prices and fees, current value, optional credit link |
+
+#### Stats / utilities
+
+| Component | Description |
+|-----------|-------------|
+| **Currency.vue** | Currency formatter (uses `store.state.compte.currency`) |
+| **Stats/SumByMonth.vue** | Monthly expense summary card |
+| **Stats/PieByCategorie.vue** | Highcharts pie chart by category |
+| **Stats/TimeSeriesEvolutionSoldes.vue** | Highcharts time series (global / retraite / dispo) |
 
 ### Views (`src/views/`)
 
 | View | Description |
 |------|-------------|
-| **Login.vue** | 6-character code input for authentication |
-| **Home.vue** | Main view: OperationList for the active account |
-| **OperationsRecurrentes.vue** | Recurring operations management |
-| **Amortissement.vue** | Amortization tracking view |
-| **Stats.vue** | Statistics dashboard with charts |
-| **Config.vue** | User settings (theme toggle, preferences) |
-| **RouteOverTheContent.vue** | Dynamic overlay wrapper for child route components |
+| **Login.vue** | 6-character code input → `auth(code)` → save cookies, dispatch `fetchUser` |
+| **Home.vue** | Active account `OperationList`; child routes overlay forms |
+| **OperationsRecurrentes.vue** | Recurring operations list and management |
+| **Amortissement.vue** | Operations filtered with `amortissement: 1` (loan principal repayments) |
+| **Credits.vue** | Loans dashboard |
+| **Biens.vue** | Real-estate assets dashboard |
+| **Stats.vue** | Dashboard composing the three Stats components |
+| **Config.vue** | Settings: reload, edit account, theme toggle, debug-tools toggle, logout |
+| **EditUser.vue** | Form to update profile (`PATCH /api/users/me`) |
+| **RouteOverTheContent.vue** | Dynamic overlay wrapper — reads `componentName` prop and renders the matching form |
 
 ### Composables (`src/composables/`)
 
-- **useTheme.ts**: Theme management composable
-  - Supports `light`, `dark`, `system` modes
-  - Persists choice to `localStorage`
-  - Listens to system `prefers-color-scheme` changes
-  - Singleton pattern via `useGlobalTheme()` for shared state
-  - Sets `data-theme` attribute and `.dark-theme` class on `<html>`
-
-### Styling
-
-- **SCSS**: Variables in `src/styles/variables.scss` (globally injected via Vite `additionalData`)
-  - Breakpoints: desktop >=768px, mobile <768px
-  - Layout: `$header-height: 70px`, `$left-panel-width: 33%`, `$navbar-height: 40px`
-- **CSS Custom Properties**: Full theme system in `src/styles/theme.css`
-  - Colors, gradients, shadows, spacing, typography, z-index
-  - Light and dark variants via `@media (prefers-color-scheme: dark)` and `html[data-theme]`
-  - Glass morphism effects
-- **Global styles**: `src/styles/main.css`
+- **`useTheme.ts`** — theme management.
+  - Modes: `light`, `dark`, `system`.
+  - Persists choice to `localStorage` under `theme`.
+  - Listens to `prefers-color-scheme` changes.
+  - Sets `data-theme` attribute and `dark-theme` class on `<html>`.
+  - Singleton via `useGlobalTheme()` for shared state.
+- **`useDebugTools.ts`** — optional Eruda integration.
+  - `localStorage` key: `debugToolsEnabled`.
+  - `initDebugTools()` reads the flag and lazy-loads Eruda (`eruda` npm package) when enabled.
+  - `toggleDebugTools()` flips the flag.
+  - Singleton via `useGlobalDebugTools()`.
+  - Toggled from `Config.vue` to enable a mobile dev console.
 
 ### Plugins (`src/plugins/`)
 
-- **fontawesome.ts**: Configures FontAwesome with `@fortawesome/free-solid-svg-icons`
+- **`fontawesome.ts`** — registers a curated set of FontAwesome solid icons; the resulting component is exposed globally as `<FontAwesomeIcon>`.
+
+### Styles (`src/styles/`)
+
+- **`variables.scss`** — SCSS variables globally injected via Vite `additionalData` (breakpoints, layout):
+  - `$desktop_BP_min_width: 768px`, `$mobile_BP_max_width: 767px`
+  - `$header-height: 70px`, `$header-height-and-margin: 80px`
+  - `$left-panel-width: 33%`, `$navbar-height: 40px`, `$navbar-height-and-margin: 70px`
+- **`theme.css`** — CSS custom properties for the full theme system: gradients, base colors, text, backgrounds (incl. glass-morphism), borders, button states, z-index. Light + dark via `@media (prefers-color-scheme: dark)` and `html[data-theme="dark"]`.
+- **`main.css`** — global resets, font stack, container/grid utilities.
 
 ### PWA Configuration
 
 Configured via `vite-plugin-pwa` in `vite.config.ts`:
-- Service worker: `service-worker.js` with `autoUpdate` registration
-- Manifest: `MCCB NG` / `MCCB`, standalone display mode
-- Icons: 192x192 and 512x512 PNG
-- Workbox for caching strategies
+
+- Manifest: name `MCCB NG`, short name `MCCB`, display `standalone`.
+- Icons: 192×192 and 512×512 PNG.
+- Service worker: `service-worker.js` registered with `autoUpdate`.
+- Workbox for caching strategies.
+- `src/registerServiceWorker.js` performs the runtime registration.
 
 ### Vite Configuration (`vite.config.ts`)
 
-- **Dev server**: Port 8080, proxies `/api` to `VITE_API_URL` (default `http://localhost:3000`)
-- **Build**: Manual chunks — `vue` (vue/vue-router/vuex), `vendor` (axios/highcharts)
-- **SCSS**: Modern compiler API, global variables injection
-- **Aliases**: `@` → `src/`
-- **Vue flags**: Options API enabled, prod devtools disabled
+- **Dev server**: port 8080, proxies `/api` to `VITE_API_URL` (default `http://localhost:3000`).
+- **Build**: manual chunks — `vue` (vue / vue-router / vuex), `vendor` (axios / highcharts).
+- **SCSS**: modern compiler API, global variables injection.
+- **Aliases**: `@` → `src/`.
+- **Vue flags**: Options API enabled, prod devtools disabled.
 
 ### Testing
 
-- **Framework**: Jest with `jest-environment-jsdom`
-- **Vue testing**: `@vue/test-utils` + `@vue/vue3-jest`
-- **TypeScript**: `ts-jest`
-- **CSS**: `identity-obj-proxy` for CSS module mocking
-- **Config**: `jest.config.js`
-- **Test location**: `tests/unit/`
-- **Lint-staged**: ESLint auto-fix on commit for `.js, .jsx, .ts, .tsx, .vue` files
+- **Framework**: Jest with `jest-environment-jsdom`.
+- **Vue testing**: `@vue/test-utils` + `@vue/vue3-jest`.
+- **TypeScript**: `ts-jest`.
+- **CSS**: `identity-obj-proxy` for CSS module mocking.
+- **Config**: `jest.config.js`.
+- **Tests**: `tests/unit/`.
+- **lint-staged**: ESLint auto-fix on commit for `.js, .jsx, .ts, .tsx, .vue`.
 
 ## Dependencies
 
 ### Runtime
-- `vue` ^3.5, `vue-router` ^4.5, `vuex` ^4.1 — Core framework
+- `vue` ^3.5, `vue-router` ^4.5, `vuex` ^4.1 — core framework
 - `axios` ^1.13 — HTTP client
-- `highcharts` ^12.2 — Charts and visualizations
-- `@fortawesome/fontawesome-svg-core`, `@fortawesome/free-solid-svg-icons`, `@fortawesome/vue-fontawesome` — Icons
-- `universal-cookie` ^4.0 — Cookie management for auth tokens
-- `hammerjs` ^2.0 — Touch gesture support
-- `vue2-touch-events` — Custom workspace touch plugin
-- `register-service-worker` — PWA service worker registration
-- `core-js` — Polyfills
+- `highcharts` ^12.2 — charts
+- `@fortawesome/fontawesome-svg-core`, `@fortawesome/free-solid-svg-icons`, `@fortawesome/vue-fontawesome` — icons
+- `universal-cookie` ^4 — cookie management for auth
+- `vue3-touch-events` ^4 — Vue 3 touch / swipe gestures (replaces former local workspace)
+- `eruda` ^3 — optional in-page mobile dev console (lazy-loaded)
+- `register-service-worker`, `core-js`
 
 ### Dev
-- `vite` ^6.3, `@vitejs/plugin-vue` ^5.2 — Build tooling
-- `vite-plugin-pwa` ^1.0, `workbox-build`, `workbox-window` — PWA
-- `typescript` ^5.8, `vue-tsc` ^2.2 — Type checking
-- `sass` ^1.86 — SCSS support
-- `jest` ^29.7, `@vue/test-utils` ^2.4 — Testing
-- `eslint` ^8.57 with Vue and TypeScript plugins — Linting
+- `vite` ^6.3, `@vitejs/plugin-vue`
+- `vite-plugin-pwa`, `workbox-build`, `workbox-window`
+- `typescript` ^5.8, `vue-tsc` ^2.2
+- `sass` ^1.86
+- `jest` ^29.7, `@vue/test-utils` ^2.4, `@vue/vue3-jest`, `ts-jest`, `babel-jest`
+- `eslint` ^8.57 + Vue / TS / Standard plugins, `lint-staged`
 
 ## Docker
 
 Multi-stage build:
-1. **Build stage** (`node:22-slim`): Install deps, run `yarn build`
-2. **Production stage** (`nginx`): Copy `dist/` to nginx html, custom `nginx.conf`
 
-Registry: `dockregistry.xju.fr/mccbng/front:{staging,latest}`
+1. **Build stage** (`node:22-slim`): install deps with pnpm, run `pnpm build`.
+2. **Production stage** (`nginx`): copy `dist/` to nginx html, custom `nginx.conf` with SPA fallback (`try_files $uri /index.html`).
+
+Registry: `dockregistry.xju.fr/mccbng/front:{staging,latest}`.
 
 ## File Structure
 
 ```
 front/
 ├── src/
-│   ├── main.ts                     # App entry point
-│   ├── App.vue                     # Root component (layout)
-│   ├── router.ts                   # Vue Router config (lazy routes)
-│   ├── registerServiceWorker.js    # PWA service worker registration
-│   ├── shims-vue.d.ts              # Vue SFC type declarations
+│   ├── main.ts                       # App entry point
+│   ├── App.vue                       # Root layout
+│   ├── router.ts                     # Vue Router config (lazy + overlay child routes)
+│   ├── registerServiceWorker.js      # PWA SW registration
+│   ├── shims-vue.d.ts                # Vue SFC type declarations
 │   ├── store/
-│   │   ├── index.ts                # Vuex store with 6 modules
-│   │   ├── user.ts                 # User state (auth, preferences)
-│   │   ├── compte.ts               # Account state (list, active, balances)
-│   │   ├── operation.ts            # Operations state (CRUD, pagination, search)
-│   │   ├── category.ts             # Categories state
-│   │   ├── stats.ts                # Statistics state (monthly, charts)
-│   │   └── display.ts              # UI display state (panel toggle)
-│   ├── services/
-│   │   ├── auth.ts                 # Authentication (login, cookies, token check)
-│   │   ├── user.ts                 # User API calls
-│   │   ├── compte.ts               # Account API calls
-│   │   ├── operation.ts            # Operation API calls (CRUD, search, recurring)
-│   │   ├── category.ts             # Category API calls
-│   │   └── stats.ts                # Statistics API calls
+│   │   ├── index.ts                  # Vuex store wiring
+│   │   ├── user.ts                   # auth, profile, maskAmount
+│   │   ├── compte.ts                 # accounts + balances
+│   │   ├── operation.ts              # operations + pagination + search
+│   │   ├── category.ts               # categories (lazy)
+│   │   ├── stats.ts                  # monthly stats + charts
+│   │   ├── display.ts                # UI panel toggle
+│   │   ├── credit.ts                 # loans + remaining balances
+│   │   └── bien.ts                   # real-estate assets
+│   ├── services/                     # axios services per domain (auth, user, compte, operation, category, stats, credit, bien)
 │   ├── composables/
-│   │   └── useTheme.ts             # Theme management (light/dark/system)
+│   │   ├── useTheme.ts               # theme system (light/dark/system)
+│   │   └── useDebugTools.ts          # Eruda lazy load
 │   ├── components/
-│   │   ├── AccountHeader.vue       # Top header with balances
-│   │   ├── NavBar.vue              # Bottom navigation
-│   │   ├── CompteList/
-│   │   │   ├── index.vue           # Account list panel
-│   │   │   └── Compte.vue          # Account list item
-│   │   ├── OperationList.vue       # Operations list with infinite scroll
-│   │   ├── OperationForm.vue       # Operation create/edit form
-│   │   ├── TransfertForm.vue       # Transfer between accounts
-│   │   ├── Search.vue              # Operation search
-│   │   ├── Currency.vue            # Currency formatting
-│   │   ├── OperationRecurrenteList.vue
-│   │   ├── OperationRecurrente.vue
-│   │   ├── OperationRecurrenteForm.vue
-│   │   ├── Home/
-│   │   │   └── Operation.vue       # Operation row (swipeable)
-│   │   ├── Amortissement/
-│   │   │   └── Operation.vue       # Amortization operation row
-│   │   └── Stats/
-│   │       ├── SumByMonth.vue      # Monthly expense summary
-│   │       ├── PieByCategorie.vue  # Category pie chart (Highcharts)
-│   │       └── TimeSeriesEvolutionSoldes.vue  # Balance evolution chart
-│   ├── views/
-│   │   ├── Login.vue               # Authentication page
-│   │   ├── Home.vue                # Main operations view
-│   │   ├── OperationsRecurrentes.vue
-│   │   ├── Amortissement.vue
-│   │   ├── Stats.vue               # Statistics dashboard
-│   │   ├── Config.vue              # User settings
-│   │   └── RouteOverTheContent.vue # Dynamic overlay for child routes
+│   │   ├── AccountHeader.vue
+│   │   ├── NavBar.vue
+│   │   ├── CompteList/{index,Compte}.vue
+│   │   ├── OperationList.vue
+│   │   ├── OperationForm.vue
+│   │   ├── TransfertForm.vue
+│   │   ├── Search.vue
+│   │   ├── OperationRecurrente{,List,Form}.vue
+│   │   ├── CreditCard.vue / CreditForm.vue / CreditList.vue
+│   │   ├── BienCard.vue / BienForm.vue / BienList.vue
+│   │   ├── Currency.vue
+│   │   ├── Home/Operation.vue
+│   │   ├── Amortissement/Operation.vue
+│   │   └── Stats/{SumByMonth,PieByCategorie,TimeSeriesEvolutionSoldes}.vue
+│   ├── views/                        # Login, Home, OperationsRecurrentes, Amortissement, Credits, Biens, Stats, Config, EditUser, RouteOverTheContent
 │   ├── plugins/
-│   │   └── fontawesome.ts          # FontAwesome icon setup
+│   │   └── fontawesome.ts
 │   └── styles/
-│       ├── variables.scss          # SCSS variables (breakpoints, layout)
-│       ├── theme.css               # CSS custom properties (light/dark theme)
-│       └── main.css                # Global styles
+│       ├── variables.scss
+│       ├── theme.css
+│       └── main.css
 ├── tests/
-│   ├── setup.js                    # Jest setup
+│   ├── setup.js
 │   └── unit/
-│       └── example.spec.js         # Example test
-├── public/                         # Static assets (icons, favicon)
-├── vite.config.ts                  # Vite configuration
-├── jest.config.js                  # Jest configuration
-├── tsconfig.json                   # TypeScript config
-├── Dockerfile                      # Multi-stage build (node + nginx)
-├── nginx.conf                      # Nginx config for SPA routing
+│       └── example.spec.js
+├── public/                           # static assets (icons, favicon)
+├── vite.config.ts
+├── jest.config.js
+├── tsconfig.json
+├── Dockerfile
+├── nginx.conf
 └── package.json
 ```
+
+## Conventions When Editing
+
+- Use `<script setup lang="ts">` and the Composition API in new components.
+- Add a new domain by creating: a `services/<domain>.ts` (axios), a `store/<domain>.ts` (module registered in `store/index.ts`), and components under `components/`.
+- Modal-style flows should be modeled as **child routes** with `RouteOverTheContent` and a `componentName` prop, not as imperative components.
+- For currency display, prefer `<Currency :amount="…" />` so the locale and symbol stay centralised.
+- Read auth from `getTokenCookie()` / `getUserIDCookie()` rather than from the Vuex store when calling services from outside Vue components.
+- Keep state mutations free of axios calls — services do the I/O, actions orchestrate.


### PR DESCRIPTION
- Rewrite root README.md with sections for features, technical
  architecture, data model, REST endpoints, setup, configuration and
  Docker deployment
- Update root CLAUDE.md to document the pnpm workspace layout (vue-touch-events
  removed, vue3-touch-events npm package used) and refresh commands
- Update back/CLAUDE.md to cover Credit, Bien, JwtService, getCurrentUserId,
  user scoping patterns, updateMe endpoint and 2026-05-02 SQL migration
- Update front/CLAUDE.md to add the credit + bien Vuex modules and
  services, EditUser view, useDebugTools composable and the new routes