### PR TITLE
feat(front): nouvelle navigation Gestion + dock liquid-glass

### DIFF
--- a/back/src/models/operation-recurrente.model.ts
+++ b/back/src/models/operation-recurrente.model.ts
@@ -75,6 +75,9 @@ export class OperationRecurrente extends Entity {
   @property({
     type: 'number',
     required: false,
+    jsonSchema: {
+      nullable: true,
+    },
   })
   IDcredit?: number;
 

--- a/back/src/models/operation.model.ts
+++ b/back/src/models/operation.model.ts
@@ -63,6 +63,9 @@ export class Operation extends Entity {
   @property({
     type: 'number',
     required: false,
+    jsonSchema: {
+      nullable: true,
+    },
   })
   IDcredit?: number;
 

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -178,7 +178,7 @@ hr {
 
 .bottom-dock {
   position: fixed;
-  bottom: 12px;
+  bottom: 15px;
   left: 50%;
   transform: translateX(-50%);
   display: flex;
@@ -187,7 +187,6 @@ hr {
   z-index: 100;
 
   @media screen and (max-width: $mobile_BP_max_width) {
-    bottom: 8px;
     gap: 6px;
   }
 }

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -207,7 +207,7 @@ hr {
   width: 56px;
   height: 56px;
   border-radius: 50%;
-  background: var(--bg-glass, rgba(255, 255, 255, 0.75));
+  background: var(--bg-dock, rgba(255, 255, 255, 0.55));
   backdrop-filter: saturate(180%) blur(20px);
   -webkit-backdrop-filter: saturate(180%) blur(20px);
   color: var(--text-primary, #2d3748);

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -25,6 +25,15 @@
       v-if="route.name !== 'Login'"
       class="bottom-dock"
     >
+      <button
+        v-if="!displayAccountList"
+        type="button"
+        class="dock-burger"
+        aria-label="Ouvrir la liste des comptes"
+        @click="openAccountList"
+      >
+        <font-awesome-icon icon="hamburger" />
+      </button>
       <NavBar />
       <FabMenu />
     </div>
@@ -190,6 +199,34 @@ hr {
   @media screen and (max-width: $mobile_BP_max_width) {
     bottom: 12px;
     gap: 8px;
+  }
+}
+
+.dock-burger {
+  display: none;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--bg-glass, rgba(255, 255, 255, 0.75));
+  backdrop-filter: saturate(180%) blur(20px);
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  color: var(--text-primary, #2d3748);
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12),
+    0 1px 0 rgba(255, 255, 255, 0.4) inset;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  cursor: pointer;
+  font-size: 20px;
+  -webkit-tap-highlight-color: transparent;
+  transition: transform 0.2s ease;
+
+  &:hover {
+    transform: scale(1.05);
+  }
+
+  @media screen and (max-width: $mobile_BP_max_width) {
+    display: flex;
   }
 }
 

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -5,12 +5,8 @@
     :class="{ 'is-login-page': route.name === 'Login' }"
   >
     <account-header :class="{ 'is-login-page': route.name === 'Login' }" />
-    <div
-      class="container-flex"
-      :class="{ 'no-side-panel': !showCompteList }"
-    >
+    <div class="container-flex">
       <div
-        v-if="showCompteList"
         class="left-panel"
         :class="{
           'mask-panel': !displayAccountList,
@@ -22,7 +18,7 @@
       <router-view
         v-touch:swipe.right="openAccountList"
         class="right-panel"
-        :class="{ 'mask-panel': displayAccountList && showCompteList }"
+        :class="{ 'mask-panel': displayAccountList }"
       />
     </div>
     <NavBar />
@@ -57,20 +53,6 @@
 
   const userID = computed(() => store.state.user.id)
   const displayAccountList = computed(() => store.state.display.account_list)
-
-  const compteContextPaths = [
-    '/',
-    '/newOperation',
-    '/search',
-    '/transfert',
-    '/retrait'
-  ]
-  const showCompteList = computed(() => {
-    if (route.name === 'Login') return false
-    if (compteContextPaths.includes(route.path)) return true
-    if (route.path.startsWith('/editOperation')) return true
-    return false
-  })
 
   watch(userID, () => {
     store.dispatch('fetchAccountList')
@@ -146,10 +128,6 @@ hr {
   @media all and (min-width: $desktop_BP_min_width) {
     .right-panel {
       width: calc(100% - #{$left-panel-width});
-    }
-
-    .container-flex.no-side-panel .right-panel {
-      width: 100%;
     }
   }
 }

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -189,7 +189,7 @@ hr {
 
   @media screen and (max-width: $mobile_BP_max_width) {
     bottom: 12px;
-    gap: 8px;
+    gap: 6px;
   }
 }
 

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -21,8 +21,13 @@
         :class="{ 'mask-panel': displayAccountList }"
       />
     </div>
-    <NavBar />
-    <FabMenu v-if="route.name !== 'Login'" />
+    <div
+      v-if="route.name !== 'Login'"
+      class="bottom-dock"
+    >
+      <NavBar />
+      <FabMenu />
+    </div>
   </div>
 </template>
 
@@ -169,6 +174,23 @@ hr {
 
 .app-header.is-login-page {
   display: none !important;
+}
+
+.bottom-dock {
+  position: fixed;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  z-index: 100;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+
+  @media screen and (max-width: $mobile_BP_max_width) {
+    bottom: 12px;
+    gap: 8px;
+  }
 }
 
 @media screen and (max-width: $mobile_BP_max_width) {

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -178,17 +178,16 @@ hr {
 
 .bottom-dock {
   position: fixed;
-  bottom: 16px;
+  bottom: 12px;
   left: 50%;
   transform: translateX(-50%);
   display: flex;
   align-items: center;
   gap: 10px;
   z-index: 100;
-  padding-bottom: env(safe-area-inset-bottom, 0px);
 
   @media screen and (max-width: $mobile_BP_max_width) {
-    bottom: 12px;
+    bottom: 8px;
     gap: 6px;
   }
 }

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -25,15 +25,6 @@
       v-if="route.name !== 'Login'"
       class="bottom-dock"
     >
-      <button
-        v-if="!displayAccountList"
-        type="button"
-        class="dock-burger"
-        aria-label="Ouvrir la liste des comptes"
-        @click="openAccountList"
-      >
-        <font-awesome-icon icon="hamburger" />
-      </button>
       <NavBar />
       <FabMenu />
     </div>
@@ -199,34 +190,6 @@ hr {
   @media screen and (max-width: $mobile_BP_max_width) {
     bottom: 12px;
     gap: 8px;
-  }
-}
-
-.dock-burger {
-  display: none;
-  width: 56px;
-  height: 56px;
-  border-radius: 50%;
-  background: var(--bg-dock, rgba(255, 255, 255, 0.55));
-  backdrop-filter: saturate(180%) blur(20px);
-  -webkit-backdrop-filter: saturate(180%) blur(20px);
-  color: var(--text-primary, #2d3748);
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12),
-    0 1px 0 rgba(255, 255, 255, 0.4) inset;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  cursor: pointer;
-  font-size: 20px;
-  -webkit-tap-highlight-color: transparent;
-  transition: transform 0.2s ease;
-
-  &:hover {
-    transform: scale(1.05);
-  }
-
-  @media screen and (max-width: $mobile_BP_max_width) {
-    display: flex;
   }
 }
 

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -5,8 +5,12 @@
     :class="{ 'is-login-page': route.name === 'Login' }"
   >
     <account-header :class="{ 'is-login-page': route.name === 'Login' }" />
-    <div class="container-flex">
+    <div
+      class="container-flex"
+      :class="{ 'no-side-panel': !showCompteList }"
+    >
       <div
+        v-if="showCompteList"
         class="left-panel"
         :class="{
           'mask-panel': !displayAccountList,
@@ -18,10 +22,11 @@
       <router-view
         v-touch:swipe.right="openAccountList"
         class="right-panel"
-        :class="{ 'mask-panel': displayAccountList }"
+        :class="{ 'mask-panel': displayAccountList && showCompteList }"
       />
     </div>
     <NavBar />
+    <FabMenu v-if="route.name !== 'Login'" />
   </div>
 </template>
 
@@ -33,6 +38,7 @@
   import { useGlobalDebugTools } from '@/composables/useDebugTools'
 
   import NavBar from '@/components/NavBar.vue'
+  import FabMenu from '@/components/FabMenu.vue'
   import CompteList from '@/components/CompteList/index.vue'
   import AccountHeader from '@/components/AccountHeader.vue'
 
@@ -51,6 +57,20 @@
 
   const userID = computed(() => store.state.user.id)
   const displayAccountList = computed(() => store.state.display.account_list)
+
+  const compteContextPaths = [
+    '/',
+    '/newOperation',
+    '/search',
+    '/transfert',
+    '/retrait'
+  ]
+  const showCompteList = computed(() => {
+    if (route.name === 'Login') return false
+    if (compteContextPaths.includes(route.path)) return true
+    if (route.path.startsWith('/editOperation')) return true
+    return false
+  })
 
   watch(userID, () => {
     store.dispatch('fetchAccountList')
@@ -126,6 +146,10 @@ hr {
   @media all and (min-width: $desktop_BP_min_width) {
     .right-panel {
       width: calc(100% - #{$left-panel-width});
+    }
+
+    .container-flex.no-side-panel .right-panel {
+      width: 100%;
     }
   }
 }

--- a/front/src/components/AccountHeader.vue
+++ b/front/src/components/AccountHeader.vue
@@ -1,13 +1,5 @@
 <template>
   <div class="app-header">
-    <div>
-      <button
-        class="btn btn-info search-button"
-        @click="searchOperation"
-      >
-        <font-awesome-icon icon="search" />
-      </button>
-    </div>
     <div class="account-info">
       <div>
         {{ activeAccount.NomCompte }}
@@ -18,25 +10,16 @@
         />]
       </div>
     </div>
-    <div class="header-actions">
-      <button
-        class="btn btn-secondary chart-button"
-        @click="goToStats"
-      >
-        <font-awesome-icon icon="chart-pie" />
-      </button>
-    </div>
   </div>
 </template>
 
 <script setup lang="ts">
   import { computed } from 'vue'
-  import { useRoute, useRouter } from 'vue-router'
+  import { useRoute } from 'vue-router'
   import { useStore } from 'vuex'
   import Currency from './Currency.vue'
 
   const route = useRoute()
-  const router = useRouter()
   const store = useStore()
 
   const activeAccount = computed(() => store.state.compte.activeAccount)
@@ -46,15 +29,6 @@
       ? false
       : route.meta.disabledTotalHeader
   })
-
-  const goToStats = () => {
-    store.dispatch('toggleAccountList', false)
-    router.push('stats')
-  }
-
-  const searchOperation = () => {
-    router.push('search')
-  }
 </script>
 
 <style lang="scss" scoped>
@@ -63,7 +37,7 @@
   height: $header-height;
   width: fit-content;
   max-width: 90%;
-  min-width: 360px;
+  min-width: 240px;
   backdrop-filter: var(--glass-blur);
   background-color: var(--bg-glass);
   border: var(--glass-border);
@@ -71,43 +45,18 @@
   left: 75%;
   transform: translateX(-75%);
   text-align: center;
-  padding: 10px;
+  padding: 10px 24px;
   z-index: 100;
   font-size: 1.1rem;
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   box-shadow: var(--shadow-glass);
-  gap: 1rem;
   border-radius: 14px;
 
   @media screen and (max-width: $mobile_BP_max_width) {
     left: 50%;
     transform: translateX(-50%);
-  }
-
-  .header-actions {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-sm);
-  }
-
-  button.chart-button,
-  button.search-button {
-    width: 45px;
-    height: 40px;
-    font-size: 1.2rem;
-    line-height: 1rem;
-    border-radius: 14px;
-    border: none;
-    backdrop-filter: blur(5px);
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    font-weight: 600;
-
-    &:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-    }
   }
 }
 

--- a/front/src/components/FabMenu.vue
+++ b/front/src/components/FabMenu.vue
@@ -1,15 +1,14 @@
 <template>
-  <div
-    v-if="actions.length > 0"
-    class="fab-wrapper"
-  >
-    <transition name="fade">
-      <div
-        v-if="expanded"
-        class="fab-backdrop"
-        @click="close"
-      />
-    </transition>
+  <div class="fab-wrapper">
+    <Teleport to="body">
+      <transition name="fade">
+        <div
+          v-if="expanded"
+          class="fab-backdrop"
+          @click="close"
+        />
+      </transition>
+    </Teleport>
 
     <transition-group
       v-if="expanded"
@@ -34,7 +33,10 @@
       type="button"
       class="fab"
       :class="{ expanded }"
-      :aria-label="expanded ? 'Fermer le menu' : 'Ouvrir le menu d\'actions'"
+      :disabled="actions.length === 0"
+      :aria-label="actions.length === 0
+        ? 'Aucune action disponible'
+        : (expanded ? 'Fermer le menu' : 'Ouvrir le menu d\'actions')"
       :aria-expanded="expanded"
       @click="toggle"
     >
@@ -101,6 +103,7 @@
   }
 
   const toggle = () => {
+    if (actions.value.length === 0) return
     expanded.value = !expanded.value
   }
 
@@ -120,16 +123,13 @@
 <style lang="scss" scoped>
 .fab-wrapper {
   position: relative;
-  z-index: 1;
 }
 
 .fab-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.3);
-  backdrop-filter: blur(2px);
-  -webkit-backdrop-filter: blur(2px);
-  z-index: 1;
+  background: transparent;
+  z-index: 90;
 }
 
 .mini-fabs {
@@ -140,12 +140,10 @@
   flex-direction: column-reverse;
   align-items: flex-end;
   gap: 12px;
-  z-index: 3;
 }
 
 .fab {
   position: relative;
-  z-index: 2;
   width: 56px;
   height: 56px;
   border-radius: 50%;
@@ -165,13 +163,18 @@
   -webkit-tap-highlight-color: transparent;
 }
 
-.fab:hover {
+.fab:not(:disabled):hover {
   transform: scale(1.05);
 }
 
 .fab.expanded {
   transform: rotate(45deg);
   color: #667eea;
+}
+
+.fab:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .mini-fab {

--- a/front/src/components/FabMenu.vue
+++ b/front/src/components/FabMenu.vue
@@ -163,13 +163,17 @@
   -webkit-tap-highlight-color: transparent;
 }
 
-.fab:not(:disabled):hover {
+.fab:not(:disabled):not(.expanded):hover {
   transform: scale(1.05);
 }
 
 .fab.expanded {
   transform: rotate(45deg);
   color: #667eea;
+}
+
+.fab.expanded:hover {
+  transform: rotate(45deg) scale(1.05);
 }
 
 .fab:disabled {

--- a/front/src/components/FabMenu.vue
+++ b/front/src/components/FabMenu.vue
@@ -147,16 +147,15 @@
   width: 56px;
   height: 56px;
   border-radius: 50%;
-  background: var(--bg-dock, rgba(255, 255, 255, 0.55));
-  backdrop-filter: saturate(180%) blur(20px);
-  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  background: transparent;
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
   color: var(--text-primary, #2d3748);
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12),
-    0 1px 0 rgba(255, 255, 255, 0.4) inset;
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.2);
   cursor: pointer;
   transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
   font-size: 20px;

--- a/front/src/components/FabMenu.vue
+++ b/front/src/components/FabMenu.vue
@@ -56,7 +56,6 @@
   const expanded = ref(false)
 
   const homeActions: Action[] = [
-    { label: 'Rechercher', icon: 'search', color: 'fab-info', path: '/search' },
     { label: 'Nouvelle opération', icon: 'plus', color: 'fab-primary', path: '/newOperation' },
     { label: 'Virement', icon: 'exchange-alt', color: 'fab-warning', path: '/transfert' }
   ]
@@ -136,7 +135,7 @@
 
 .fab-stack {
   display: flex;
-  flex-direction: column-reverse;
+  flex-direction: column;
   align-items: flex-end;
   gap: 12px;
   pointer-events: auto;

--- a/front/src/components/FabMenu.vue
+++ b/front/src/components/FabMenu.vue
@@ -129,11 +129,13 @@
   background: rgba(0, 0, 0, 0.3);
   backdrop-filter: blur(2px);
   -webkit-backdrop-filter: blur(2px);
-  z-index: 105;
+  z-index: 1;
   pointer-events: auto;
 }
 
 .fab-stack {
+  position: relative;
+  z-index: 2;
   display: flex;
   flex-direction: column;
   align-items: flex-end;

--- a/front/src/components/FabMenu.vue
+++ b/front/src/components/FabMenu.vue
@@ -11,32 +11,35 @@
       />
     </transition>
 
-    <div class="fab-stack">
-      <transition-group name="pop">
-        <button
-          v-for="action in expanded ? actions : []"
-          :key="action.label"
-          type="button"
-          class="mini-fab"
-          :class="action.color"
-          @click="run(action)"
-        >
-          <span class="mini-fab-label">{{ action.label }}</span>
-          <font-awesome-icon :icon="action.icon" />
-        </button>
-      </transition-group>
-
+    <transition-group
+      v-if="expanded"
+      name="pop"
+      tag="div"
+      class="mini-fabs"
+    >
       <button
+        v-for="action in actions"
+        :key="action.label"
         type="button"
-        class="fab"
-        :class="{ expanded }"
-        :aria-label="expanded ? 'Fermer le menu' : 'Ouvrir le menu d\'actions'"
-        :aria-expanded="expanded"
-        @click="toggle"
+        class="mini-fab"
+        :class="action.color"
+        @click="run(action)"
       >
-        <font-awesome-icon icon="plus" />
+        <span class="mini-fab-label">{{ action.label }}</span>
+        <font-awesome-icon :icon="action.icon" />
       </button>
-    </div>
+    </transition-group>
+
+    <button
+      type="button"
+      class="fab"
+      :class="{ expanded }"
+      :aria-label="expanded ? 'Fermer le menu' : 'Ouvrir le menu d\'actions'"
+      :aria-expanded="expanded"
+      @click="toggle"
+    >
+      <font-awesome-icon icon="plus" />
+    </button>
   </div>
 </template>
 
@@ -116,11 +119,8 @@
 
 <style lang="scss" scoped>
 .fab-wrapper {
-  position: fixed;
-  right: 16px;
-  bottom: calc(#{$navbar-height-and-margin} + env(safe-area-inset-bottom, 0px));
-  z-index: 110;
-  pointer-events: none;
+  position: relative;
+  z-index: 1;
 }
 
 .fab-backdrop {
@@ -130,33 +130,38 @@
   backdrop-filter: blur(2px);
   -webkit-backdrop-filter: blur(2px);
   z-index: 1;
-  pointer-events: auto;
 }
 
-.fab-stack {
-  position: relative;
-  z-index: 2;
+.mini-fabs {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 12px);
   display: flex;
-  flex-direction: column;
+  flex-direction: column-reverse;
   align-items: flex-end;
   gap: 12px;
-  pointer-events: auto;
+  z-index: 3;
 }
 
 .fab {
+  position: relative;
+  z-index: 2;
   width: 56px;
   height: 56px;
   border-radius: 50%;
-  background: var(--primary-gradient, linear-gradient(135deg, #667eea 0%, #764ba2 100%));
-  color: #fff;
+  background: var(--bg-glass, rgba(255, 255, 255, 0.75));
+  backdrop-filter: saturate(180%) blur(20px);
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  color: var(--text-primary, #2d3748);
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 8px 20px rgba(102, 126, 234, 0.4);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12),
+    0 1px 0 rgba(255, 255, 255, 0.4) inset;
+  border: 1px solid rgba(255, 255, 255, 0.18);
   cursor: pointer;
   transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
-  font-size: 22px;
-  border: none;
+  font-size: 20px;
   -webkit-tap-highlight-color: transparent;
 }
 
@@ -166,6 +171,7 @@
 
 .fab.expanded {
   transform: rotate(45deg);
+  color: #667eea;
 }
 
 .mini-fab {
@@ -196,11 +202,15 @@
 .fab-bien { background: linear-gradient(135deg, #e83e8c, #c42a60); }
 
 .pop-enter-active {
-  transition: opacity 0.2s ease, transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transition:
+    opacity 0.2s ease,
+    transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .pop-leave-active {
-  transition: opacity 0.15s ease, transform 0.15s ease;
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
 }
 
 .pop-enter-from {

--- a/front/src/components/FabMenu.vue
+++ b/front/src/components/FabMenu.vue
@@ -1,0 +1,224 @@
+<template>
+  <div
+    v-if="actions.length > 0"
+    class="fab-wrapper"
+  >
+    <transition name="fade">
+      <div
+        v-if="expanded"
+        class="fab-backdrop"
+        @click="close"
+      />
+    </transition>
+
+    <div class="fab-stack">
+      <transition-group name="pop">
+        <button
+          v-for="action in expanded ? actions : []"
+          :key="action.label"
+          type="button"
+          class="mini-fab"
+          :class="action.color"
+          @click="run(action)"
+        >
+          <span class="mini-fab-label">{{ action.label }}</span>
+          <font-awesome-icon :icon="action.icon" />
+        </button>
+      </transition-group>
+
+      <button
+        type="button"
+        class="fab"
+        :class="{ expanded }"
+        :aria-label="expanded ? 'Fermer le menu' : 'Ouvrir le menu d\'actions'"
+        :aria-expanded="expanded"
+        @click="toggle"
+      >
+        <font-awesome-icon icon="plus" />
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { computed, ref, watch } from 'vue'
+  import { useRoute, useRouter } from 'vue-router'
+
+  type Action = {
+    label: string
+    icon: string
+    color: string
+    path: string
+  }
+
+  const route = useRoute()
+  const router = useRouter()
+  const expanded = ref(false)
+
+  const homeActions: Action[] = [
+    { label: 'Rechercher', icon: 'search', color: 'fab-info', path: '/search' },
+    { label: 'Nouvelle opération', icon: 'plus', color: 'fab-primary', path: '/newOperation' },
+    { label: 'Virement', icon: 'exchange-alt', color: 'fab-warning', path: '/transfert' }
+  ]
+
+  const gestionActions: Action[] = [
+    { label: 'Nouvelle récurrente', icon: 'retweet', color: 'fab-info', path: '/newRecurrOperation' },
+    { label: 'Nouveau crédit', icon: 'credit-card', color: 'fab-credit', path: '/newCredit' },
+    { label: 'Nouveau bien', icon: 'home', color: 'fab-bien', path: '/newBien' }
+  ]
+
+  const isHomeContext = (path: string) =>
+    path === '/' ||
+    path === '/newOperation' ||
+    path.startsWith('/editOperation') ||
+    path === '/search' ||
+    path === '/transfert' ||
+    path === '/retrait'
+
+  const isGestionContext = (path: string) =>
+    path === '/gestion' ||
+    path === '/credits' ||
+    path === '/biens' ||
+    path === '/recurrOperation' ||
+    path === '/amortissement' ||
+    path === '/newRecurrOperation' ||
+    path.startsWith('/editRecurrOperation') ||
+    path === '/newCredit' ||
+    path.startsWith('/editCredit') ||
+    path === '/newBien' ||
+    path.startsWith('/editBien')
+
+  const actions = computed<Action[]>(() => {
+    if (isHomeContext(route.path)) return homeActions
+    if (isGestionContext(route.path)) return gestionActions
+    return []
+  })
+
+  const close = () => {
+    expanded.value = false
+  }
+
+  const toggle = () => {
+    expanded.value = !expanded.value
+  }
+
+  const run = (action: Action) => {
+    expanded.value = false
+    router.push(action.path)
+  }
+
+  watch(
+    () => route.path,
+    () => {
+      expanded.value = false
+    }
+  )
+</script>
+
+<style lang="scss" scoped>
+.fab-wrapper {
+  position: fixed;
+  right: 16px;
+  bottom: calc(#{$navbar-height-and-margin} + env(safe-area-inset-bottom, 0px));
+  z-index: 110;
+  pointer-events: none;
+}
+
+.fab-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  z-index: 105;
+  pointer-events: auto;
+}
+
+.fab-stack {
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: flex-end;
+  gap: 12px;
+  pointer-events: auto;
+}
+
+.fab {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--primary-gradient, linear-gradient(135deg, #667eea 0%, #764ba2 100%));
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 8px 20px rgba(102, 126, 234, 0.4);
+  cursor: pointer;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  font-size: 22px;
+  border: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.fab:hover {
+  transform: scale(1.05);
+}
+
+.fab.expanded {
+  transform: rotate(45deg);
+}
+
+.mini-fab {
+  height: 44px;
+  border-radius: 22px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 16px;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.mini-fab-label {
+  white-space: nowrap;
+}
+
+.fab-primary { background: linear-gradient(135deg, #007bff, #0056b3); }
+.fab-warning { background: linear-gradient(135deg, #ffc107, #e0a800); color: #212529; }
+.fab-info { background: linear-gradient(135deg, #17a2b8, #117a8b); }
+.fab-credit { background: linear-gradient(135deg, #6f42c1, #4e2a8e); }
+.fab-bien { background: linear-gradient(135deg, #e83e8c, #c42a60); }
+
+.pop-enter-active {
+  transition: opacity 0.2s ease, transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.pop-leave-active {
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.pop-enter-from {
+  opacity: 0;
+  transform: scale(0.6) translateY(20px);
+}
+
+.pop-leave-to {
+  opacity: 0;
+  transform: scale(0.8) translateY(10px);
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/front/src/components/FabMenu.vue
+++ b/front/src/components/FabMenu.vue
@@ -147,7 +147,7 @@
   width: 56px;
   height: 56px;
   border-radius: 50%;
-  background: var(--bg-glass, rgba(255, 255, 255, 0.75));
+  background: var(--bg-dock, rgba(255, 255, 255, 0.55));
   backdrop-filter: saturate(180%) blur(20px);
   -webkit-backdrop-filter: saturate(180%) blur(20px);
   color: var(--text-primary, #2d3748);

--- a/front/src/components/NavBar.vue
+++ b/front/src/components/NavBar.vue
@@ -166,7 +166,7 @@
 }
 
 .nav-bar {
-  padding: 8px 16px;
+  padding: 6px 10px;
   height: auto;
   width: fit-content;
   max-width: 90%;
@@ -175,18 +175,23 @@
   left: 50%;
   transform: translateX(-50%);
   display: inline-flex;
+  align-items: center;
+  gap: 8px;
   text-align: center;
   z-index: 100;
-  border-radius: 14px;
+  border-radius: 18px;
+  background-color: var(--bg-glass, rgba(255, 255, 255, 0.6));
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
-  backdrop-filter: blur(5px);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   border: 1px solid rgba(255, 255, 255, 0.2);
 
   @media screen and (max-width: $mobile_BP_max_width) {
     width: fit-content;
     max-width: 95%;
     bottom: 16px;
-    padding: 6px 12px;
+    padding: 5px 8px;
+    gap: 6px;
   }
 
   &.btn-group {
@@ -195,21 +200,11 @@
       height: $navbar-height;
       width: 3rem;
       border: none;
-      backdrop-filter: blur(5px);
-      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+      transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
       font-size: 1.2rem;
       font-weight: 600;
-      border-radius: 0;
-
-      &:first-child {
-        border-top-left-radius: 14px;
-        border-bottom-left-radius: 14px;
-      }
-
-      &:last-child {
-        border-top-right-radius: 14px;
-        border-bottom-right-radius: 14px;
-      }
+      border-radius: 12px;
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 
       &:hover {
         transform: translateY(-2px);
@@ -218,7 +213,7 @@
 
       &.active {
         transform: translateY(-1px);
-        box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.85),
+        box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.9),
           0 4px 12px rgba(0, 0, 0, 0.25);
       }
     }

--- a/front/src/components/NavBar.vue
+++ b/front/src/components/NavBar.vue
@@ -101,7 +101,7 @@
   gap: 4px;
   padding: 6px 8px;
   border-radius: 28px;
-  background: var(--bg-glass, rgba(255, 255, 255, 0.75));
+  background: var(--bg-dock, rgba(255, 255, 255, 0.55));
   backdrop-filter: saturate(180%) blur(20px);
   -webkit-backdrop-filter: saturate(180%) blur(20px);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12),

--- a/front/src/components/NavBar.vue
+++ b/front/src/components/NavBar.vue
@@ -190,12 +190,22 @@
 }
 
 @media screen and (max-width: $mobile_BP_max_width) {
+  .tab-bar {
+    gap: 0;
+    padding: 5px 6px;
+  }
+
   .tab {
-    width: 58px;
+    width: 54px;
+    padding: 5px 2px;
   }
 
   .tab-icon {
     font-size: 19px;
+  }
+
+  .tab-label {
+    font-size: 9px;
   }
 
   .tab-burger {

--- a/front/src/components/NavBar.vue
+++ b/front/src/components/NavBar.vue
@@ -1,570 +1,134 @@
 <template>
-  <div
-    class="nav-bar btn-group"
-    role="group"
+  <nav
+    v-if="route.name !== 'Login'"
+    class="tab-bar"
+    role="navigation"
+    aria-label="Navigation principale"
   >
     <button
-      class="btn btn-secondary left-panel-button"
-      :disabled="route.name === 'Login'"
-      @click="burgerMenuClick"
+      v-for="tab in tabs"
+      :key="tab.path"
+      type="button"
+      class="tab"
+      :class="{ active: tab.match(route) }"
+      @click="goTo(tab.path)"
     >
-      <font-awesome-icon icon="hamburger" />
+      <font-awesome-icon
+        class="tab-icon"
+        :icon="tab.icon"
+      />
+      <span class="tab-label">{{ tab.label }}</span>
     </button>
-    <button
-      class="btn btn-warning virement-button"
-      :disabled="disabled.valueOf()"
-      @click="doTransfert"
-    >
-      <font-awesome-icon icon="exchange-alt" />
-    </button>
-    <button
-      class="btn btn-primary new-operation-button"
-      :disabled="disabled.valueOf() && route.name !== 'Opérations récurrentes' && route.name !== 'Crédits' && route.name !== 'Biens'"
-      @click="addOperation"
-    >
-      <font-awesome-icon icon="plus" />
-    </button>
-    <button
-      class="btn btn-info operation-recurrente-button"
-      :disabled="route.name === 'Login'"
-      @click="getRecurrenteOp"
-    >
-      <font-awesome-icon icon="retweet" />
-    </button>
-    <button
-      class="btn btn-success amortissement-button"
-      :disabled="route.name === 'Login'"
-      @click="getAmortissement"
-    >
-      <font-awesome-icon icon="history" />
-    </button>
-    <button
-      class="btn btn-credit credit-button"
-      :disabled="route.name === 'Login'"
-      @click="getCredits"
-    >
-      <font-awesome-icon icon="credit-card" />
-    </button>
-    <button
-      class="btn btn-bien bien-button"
-      :disabled="route.name === 'Login'"
-      @click="getBiens"
-    >
-      <font-awesome-icon icon="home" />
-    </button>
-    <button
-      class="btn btn-danger params-button"
-      @click="changeParams"
-    >
-      <font-awesome-icon icon="cogs" />
-    </button>
-  </div>
+  </nav>
 </template>
 
 <script setup lang="ts">
-  import { computed, type ComputedRef } from 'vue'
   import { useRoute, useRouter } from 'vue-router'
   import { useStore } from 'vuex'
+  import type { RouteLocationNormalizedLoaded } from 'vue-router'
 
   const route = useRoute()
   const router = useRouter()
   const store = useStore()
 
-  const disabled: ComputedRef<boolean> = computed(() => {
-    return route.meta.disabledTotalHeader === undefined
-      ? false
-      : Boolean(route.meta.disabledTotalHeader)
-  })
-
-  const burgerMenuClick = () => {
-    store.dispatch('toggleAccountList')
+  type Tab = {
+    label: string
+    icon: string
+    path: string
+    match: (r: RouteLocationNormalizedLoaded) => boolean
   }
 
-  const addOperation = () => {
+  const gestionPaths = ['/gestion', '/credits', '/biens', '/recurrOperation', '/amortissement']
+  const settingsPaths = ['/config', '/editUser']
+
+  const isHomeRoute = (r: RouteLocationNormalizedLoaded) =>
+    r.path === '/' ||
+    r.path === '/newOperation' ||
+    r.path.startsWith('/editOperation') ||
+    r.path === '/search' ||
+    r.path === '/transfert' ||
+    r.path === '/retrait'
+
+  const isGestionRoute = (r: RouteLocationNormalizedLoaded) =>
+    gestionPaths.some((p) => r.path === p || r.path.startsWith(p + '/')) ||
+    r.path === '/newRecurrOperation' ||
+    r.path.startsWith('/editRecurrOperation') ||
+    r.path === '/newCredit' ||
+    r.path.startsWith('/editCredit') ||
+    r.path === '/newBien' ||
+    r.path.startsWith('/editBien')
+
+  const tabs: Tab[] = [
+    { label: 'Comptes', icon: 'wallet', path: '/', match: isHomeRoute },
+    { label: 'Gestion', icon: 'building', path: '/gestion', match: isGestionRoute },
+    { label: 'Stats', icon: 'chart-pie', path: '/stats', match: (r) => r.path === '/stats' },
+    { label: 'Réglages', icon: 'cogs', path: '/config', match: (r) => settingsPaths.includes(r.path) }
+  ]
+
+  const goTo = (path: string) => {
     store.dispatch('toggleAccountList', false)
-    if (route.name === 'Opérations récurrentes') {
-      router.push('/newRecurrOperation')
-    } else if (route.name === 'Crédits') {
-      router.push('/newCredit')
-    } else if (route.name === 'Biens') {
-      router.push('/newBien')
-    } else {
-      router.push('/newOperation')
+    if (route.path !== path) {
+      router.push(path)
     }
-  }
-
-  const doTransfert = () => {
-    store.dispatch('toggleAccountList', false)
-    router.push('/transfert')
-  }
-
-  const getRecurrenteOp = () => {
-    store.dispatch('toggleAccountList', false)
-    router.push('/recurrOperation')
-  }
-
-  const getAmortissement = () => {
-    store.dispatch('toggleAccountList', false)
-    router.push('/amortissement')
-  }
-
-  const getCredits = () => {
-    store.dispatch('toggleAccountList', false)
-    router.push('/credits')
-  }
-
-  const getBiens = () => {
-    store.dispatch('toggleAccountList', false)
-    router.push('/biens')
-  }
-
-  const changeParams = () => {
-    store.dispatch('toggleAccountList', false)
-    router.push('/config')
   }
 </script>
 
 <style lang="scss" scoped>
-.btn {
-  display: inline-block;
-  font-weight: 400;
-  color: #212529;
-  text-align: center;
-  vertical-align: middle;
-  cursor: pointer;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  background-color: transparent;
-  border: 1px solid transparent;
-  padding: 0.375rem 0.75rem;
-  font-size: 1rem;
-  line-height: 1.5;
-  border-radius: 0.25rem;
-  transition:
-    color 0.15s ease-in-out,
-    background-color 0.15s ease-in-out,
-    border-color 0.15s ease-in-out,
-    box-shadow 0.15s ease-in-out;
-  text-decoration: none;
-}
-
-.btn.disabled,
-.btn:disabled {
-  opacity: 0.65;
-}
-
-.btn-warning {
-  color: #212529;
-  background-color: #ffc107;
-  border-color: #ffc107;
-}
-
-.btn-warning:hover {
-  color: #212529;
-  background-color: #e0a800;
-  border-color: #d39e00;
-}
-
-.btn-warning:focus,
-.btn-warning.focus {
-  color: #212529;
-  background-color: #e0a800;
-  border-color: #d39e00;
-  box-shadow: 0 0 0 0.2rem rgba(222, 170, 12, 0.5);
-}
-
-.btn-warning.disabled,
-.btn-warning:disabled {
-  color: #212529;
-  background-color: #ffc107;
-  border-color: #ffc107;
-}
-
-.btn-warning:not(:disabled):not(.disabled):active,
-.btn-warning:not(:disabled):not(.disabled).active {
-  color: #212529;
-  background-color: #d39e00;
-  border-color: #c69500;
-}
-
-.btn-warning:not(:disabled):not(.disabled):active:focus,
-.btn-warning:not(:disabled):not(.disabled).active:focus {
-  box-shadow: 0 0 0 0.2rem rgba(222, 170, 12, 0.5);
-}
-
-.btn-danger {
-  color: #fff;
-  background-color: #dc3545;
-  border-color: #dc3545;
-}
-
-.btn-danger:hover {
-  color: #fff;
-  background-color: #c82333;
-  border-color: #bd2130;
-}
-
-.btn-danger:focus,
-.btn-danger.focus {
-  color: #fff;
-  background-color: #c82333;
-  border-color: #bd2130;
-  box-shadow: 0 0 0 0.2rem rgba(225, 83, 97, 0.5);
-}
-
-.btn-danger.disabled,
-.btn-danger:disabled {
-  color: #fff;
-  background-color: #dc3545;
-  border-color: #dc3545;
-}
-
-.btn-danger:not(:disabled):not(.disabled):active,
-.btn-danger:not(:disabled):not(.disabled).active {
-  color: #fff;
-  background-color: #bd2130;
-  border-color: #b21f2d;
-}
-
-.btn-danger:not(:disabled):not(.disabled):active:focus,
-.btn-danger:not(:disabled):not(.disabled).active:focus {
-  box-shadow: 0 0 0 0.2rem rgba(225, 83, 97, 0.5);
-}
-
-.btn-success {
-  color: #fff;
-  background-color: #28a745;
-  border-color: #28a745;
-}
-
-.btn-success:hover {
-  color: #fff;
-  background-color: #218838;
-  border-color: #1e7e34;
-}
-
-.btn-success:focus,
-.btn-success.focus {
-  color: #fff;
-  background-color: #218838;
-  border-color: #1e7e34;
-  box-shadow: 0 0 0 0.2rem rgba(72, 180, 97, 0.5);
-}
-
-.btn-success.disabled,
-.btn-success:disabled {
-  color: #fff;
-  background-color: #28a745;
-  border-color: #28a745;
-}
-
-.btn-success:not(:disabled):not(.disabled):active,
-.btn-success:not(:disabled):not(.disabled).active {
-  color: #fff;
-  background-color: #1e7e34;
-  border-color: #1c7430;
-}
-
-.btn-success:not(:disabled):not(.disabled):active:focus,
-.btn-success:not(:disabled):not(.disabled).active:focus {
-  box-shadow: 0 0 0 0.2rem rgba(72, 180, 97, 0.5);
-}
-
-.btn-bien {
-  color: #fff;
-  background-color: #e83e8c;
-  border-color: #e83e8c;
-}
-
-.btn-bien:hover {
-  color: #fff;
-  background-color: #d6336c;
-  border-color: #c42a60;
-}
-
-.btn-bien:focus,
-.btn-bien.focus {
-  color: #fff;
-  background-color: #d6336c;
-  border-color: #c42a60;
-  box-shadow: 0 0 0 0.2rem rgba(232, 62, 140, 0.5);
-}
-
-.btn-bien.disabled,
-.btn-bien:disabled {
-  color: #fff;
-  background-color: #e83e8c;
-  border-color: #e83e8c;
-}
-
-.btn-bien:not(:disabled):not(.disabled):active,
-.btn-bien:not(:disabled):not(.disabled).active {
-  color: #fff;
-  background-color: #c42a60;
-  border-color: #ad2354;
-}
-
-.btn-bien:not(:disabled):not(.disabled):active:focus,
-.btn-bien:not(:disabled):not(.disabled).active:focus {
-  box-shadow: 0 0 0 0.2rem rgba(232, 62, 140, 0.5);
-}
-
-.btn-credit {
-  color: #fff;
-  background-color: #6f42c1;
-  border-color: #6f42c1;
-}
-
-.btn-credit:hover {
-  color: #fff;
-  background-color: #5a32a3;
-  border-color: #4e2a8e;
-}
-
-.btn-credit:focus,
-.btn-credit.focus {
-  color: #fff;
-  background-color: #5a32a3;
-  border-color: #4e2a8e;
-  box-shadow: 0 0 0 0.2rem rgba(111, 66, 193, 0.5);
-}
-
-.btn-credit.disabled,
-.btn-credit:disabled {
-  color: #fff;
-  background-color: #6f42c1;
-  border-color: #6f42c1;
-}
-
-.btn-credit:not(:disabled):not(.disabled):active,
-.btn-credit:not(:disabled):not(.disabled).active {
-  color: #fff;
-  background-color: #4e2a8e;
-  border-color: #432578;
-}
-
-.btn-credit:not(:disabled):not(.disabled):active:focus,
-.btn-credit:not(:disabled):not(.disabled).active:focus {
-  box-shadow: 0 0 0 0.2rem rgba(111, 66, 193, 0.5);
-}
-
-.btn-info {
-  color: #fff;
-  background-color: #17a2b8;
-  border-color: #17a2b8;
-}
-
-.btn-info:hover {
-  color: #fff;
-  background-color: #138496;
-  border-color: #117a8b;
-}
-
-.btn-info:focus,
-.btn-info.focus {
-  color: #fff;
-  background-color: #138496;
-  border-color: #117a8b;
-  box-shadow: 0 0 0 0.2rem rgba(58, 176, 195, 0.5);
-}
-
-.btn-info.disabled,
-.btn-info:disabled {
-  color: #fff;
-  background-color: #17a2b8;
-  border-color: #17a2b8;
-}
-
-.btn-info:not(:disabled):not(.disabled):active,
-.btn-info:not(:disabled):not(.disabled).active {
-  color: #fff;
-  background-color: #117a8b;
-  border-color: #10707f;
-}
-
-.btn-info:not(:disabled):not(.disabled):active:focus,
-.btn-info:not(:disabled):not(.disabled).active:focus {
-  box-shadow: 0 0 0 0.2rem rgba(58, 176, 195, 0.5);
-}
-
-.btn-primary {
-  color: #fff;
-  background-color: #007bff;
-  border-color: #007bff;
-}
-
-.btn-primary:hover {
-  color: #fff;
-  background-color: #0069d9;
-  border-color: #0062cc;
-}
-
-.btn-primary:focus,
-.btn-primary.focus {
-  color: #fff;
-  background-color: #0069d9;
-  border-color: #0062cc;
-  box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5);
-}
-
-.btn-primary.disabled,
-.btn-primary:disabled {
-  color: #fff;
-  background-color: #007bff;
-  border-color: #007bff;
-}
-
-.btn-primary:not(:disabled):not(.disabled):active,
-.btn-primary:not(:disabled):not(.disabled).active {
-  color: #fff;
-  background-color: #0062cc;
-  border-color: #005cbf;
-}
-
-.btn-primary:not(:disabled):not(.disabled):active:focus,
-.btn-primary:not(:disabled):not(.disabled).active:focus {
-  box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5);
-}
-
-.btn-secondary {
-  color: #fff;
-  background-color: #6c757d;
-  border-color: #6c757d;
-}
-
-.btn-secondary:hover {
-  color: #fff;
-  background-color: #5a6268;
-  border-color: #545b62;
-}
-
-.btn-secondary:focus,
-.btn-secondary.focus {
-  color: #fff;
-  background-color: #5a6268;
-  border-color: #545b62;
-  box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.5);
-}
-
-.btn-secondary.disabled,
-.btn-secondary:disabled {
-  color: #fff;
-  background-color: #6c757d;
-  border-color: #6c757d;
-}
-
-.btn-secondary:not(:disabled):not(.disabled):active,
-.btn-secondary:not(:disabled):not(.disabled).active {
-  color: #fff;
-  background-color: #545b62;
-  border-color: #4e555b;
-}
-
-.btn-secondary:not(:disabled):not(.disabled):active:focus,
-.btn-secondary:not(:disabled):not(.disabled).active:focus {
-  box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.5);
-}
-
-.nav-bar {
-  padding: 8px 16px;
-  height: auto;
-  width: fit-content;
-  max-width: 90%;
+.tab-bar {
   position: fixed;
-  bottom: 20px;
-  left: 50%;
-  transform: translateX(-50%);
-  display: inline-flex;
-  text-align: center;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: $navbar-height;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  background: var(--bg-glass, rgba(255, 255, 255, 0.95));
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-top: 1px solid var(--border-color, rgba(0, 0, 0, 0.08));
+  display: flex;
+  justify-content: space-around;
+  align-items: stretch;
   z-index: 100;
-  border-radius: 14px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
-  backdrop-filter: blur(5px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.05);
+}
 
-  @media screen and (max-width: $mobile_BP_max_width) {
-    width: fit-content;
-    max-width: 95%;
-    bottom: 16px;
-    padding: 6px 12px;
-  }
+.tab {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 6px 4px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--text-secondary, #a0aec0);
+  transition: color 0.2s ease, transform 0.2s ease;
+  font: inherit;
+  -webkit-tap-highlight-color: transparent;
+}
 
-  a {
-    svg {
-      margin-top: 4px;
-    }
-  }
+.tab:hover {
+  color: var(--text-primary, #4a5568);
+}
 
-  &.btn-group {
-    position: fixed;
+.tab.active {
+  color: var(--primary-color, #667eea);
+}
 
-    .btn {
-      border-radius: 14px;
-      margin: 0 6px;
-      height: $navbar-height;
-      width: 3rem;
-      border: none;
-      backdrop-filter: blur(5px);
-      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-      font-size: 1.2rem;
-      font-weight: 600;
-      border-top-right-radius: 14px;
-      border-bottom-right-radius: 14px;
+.tab.active .tab-icon {
+  transform: scale(1.1);
+}
 
-      &:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-      }
+.tab-icon {
+  font-size: 20px;
+  transition: transform 0.2s ease;
+}
 
-      @media screen and (max-width: $mobile_BP_max_width) {
-        padding-bottom: 18px;
-      }
-
-      @media screen and (min-width: $mobile_BP_max_width) {
-        &.left-panel-button {
-          display: none;
-        }
-      }
-
-      &.virement-button {
-        border-top-right-radius: 0px;
-        border-bottom-right-radius: 0px;
-        margin-right: 0;
-      }
-      &.new-operation-button {
-        border-top-left-radius: 0px;
-        border-bottom-left-radius: 0px;
-        margin-left: 0;
-      }
-      &.operation-recurrente-button {
-        border-top-right-radius: 0px;
-        border-bottom-right-radius: 0px;
-        margin-right: 0;
-      }
-      &.amortissement-button {
-        border-top-left-radius: 0px;
-        border-bottom-left-radius: 0px;
-        border-top-right-radius: 0px;
-        border-bottom-right-radius: 0px;
-        margin-left: 0;
-        margin-right: 0;
-      }
-      &.credit-button {
-        border-top-left-radius: 0px;
-        border-bottom-left-radius: 0px;
-        border-top-right-radius: 0px;
-        border-bottom-right-radius: 0px;
-        margin-left: 0;
-        margin-right: 0;
-      }
-      &.bien-button {
-        border-top-left-radius: 0px;
-        border-bottom-left-radius: 0px;
-        margin-left: 0;
-      }
-    }
-  }
+.tab-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
 }
 </style>

--- a/front/src/components/NavBar.vue
+++ b/front/src/components/NavBar.vue
@@ -11,6 +11,7 @@
       type="button"
       class="tab"
       :class="{ active: tab.match(route) }"
+      :style="{ '--tab-color': tab.color }"
       :aria-current="tab.match(route) ? 'page' : undefined"
       @click="goTo(tab.path)"
     >
@@ -36,6 +37,7 @@
     label: string
     icon: string
     path: string
+    color: string
     match: (r: RouteLocationNormalizedLoaded) => boolean
   }
 
@@ -58,24 +60,28 @@
       label: 'Recherche',
       icon: 'search',
       path: '/search',
+      color: '#17a2b8',
       match: (r) => r.path === '/search'
     },
     {
       label: 'Gestion',
       icon: 'building',
       path: '/gestion',
+      color: '#6f42c1',
       match: isGestionRoute
     },
     {
       label: 'Stats',
       icon: 'chart-pie',
       path: '/stats',
+      color: '#e0a800',
       match: (r) => r.path === '/stats'
     },
     {
       label: 'Réglages',
       icon: 'cogs',
       path: '/config',
+      color: '#dc3545',
       match: isSettingsRoute
     }
   ]
@@ -104,6 +110,7 @@
 }
 
 .tab {
+  --tab-color: #2d3748;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -117,7 +124,6 @@
   border-radius: 22px;
   color: var(--text-primary, #2d3748);
   transition:
-    color 0.2s ease,
     background-color 0.2s ease,
     transform 0.2s ease;
   font: inherit;
@@ -125,11 +131,11 @@
 }
 
 .tab:hover {
-  background: rgba(0, 0, 0, 0.04);
+  background: color-mix(in srgb, var(--tab-color) 12%, transparent);
 }
 
 .tab.active {
-  color: #667eea;
+  background: color-mix(in srgb, var(--tab-color) 16%, transparent);
 }
 
 .tab.active .tab-icon {
@@ -137,11 +143,13 @@
 }
 
 .tab.active .tab-label {
+  color: var(--tab-color);
   font-weight: 700;
 }
 
 .tab-icon {
   font-size: 20px;
+  color: var(--tab-color);
   transition: transform 0.2s ease;
 }
 

--- a/front/src/components/NavBar.vue
+++ b/front/src/components/NavBar.vue
@@ -1,23 +1,26 @@
 <template>
-  <div
+  <nav
     v-if="route.name !== 'Login'"
-    class="nav-bar btn-group"
-    role="group"
+    class="tab-bar"
+    role="navigation"
     aria-label="Navigation principale"
   >
     <button
       v-for="tab in tabs"
       :key="tab.path"
       type="button"
-      class="btn"
-      :class="[tab.colorClass, { active: tab.match(route) }]"
-      :aria-label="tab.label"
+      class="tab"
+      :class="{ active: tab.match(route) }"
       :aria-current="tab.match(route) ? 'page' : undefined"
       @click="goTo(tab.path)"
     >
-      <font-awesome-icon :icon="tab.icon" />
+      <font-awesome-icon
+        class="tab-icon"
+        :icon="tab.icon"
+      />
+      <span class="tab-label">{{ tab.label }}</span>
     </button>
-  </div>
+  </nav>
 </template>
 
 <script setup lang="ts">
@@ -33,7 +36,6 @@
     label: string
     icon: string
     path: string
-    colorClass: string
     match: (r: RouteLocationNormalizedLoaded) => boolean
   }
 
@@ -56,28 +58,24 @@
       label: 'Recherche',
       icon: 'search',
       path: '/search',
-      colorClass: 'btn-info',
       match: (r) => r.path === '/search'
     },
     {
       label: 'Gestion',
       icon: 'building',
       path: '/gestion',
-      colorClass: 'btn-credit',
       match: isGestionRoute
     },
     {
       label: 'Stats',
       icon: 'chart-pie',
       path: '/stats',
-      colorClass: 'btn-warning',
       match: (r) => r.path === '/stats'
     },
     {
       label: 'Réglages',
       icon: 'cogs',
       path: '/config',
-      colorClass: 'btn-danger',
       match: isSettingsRoute
     }
   ]
@@ -91,132 +89,79 @@
 </script>
 
 <style lang="scss" scoped>
-.btn {
-  display: inline-block;
-  font-weight: 400;
-  color: #fff;
-  text-align: center;
-  vertical-align: middle;
-  cursor: pointer;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  background-color: transparent;
-  border: 1px solid transparent;
-  padding: 0.375rem 0.75rem;
-  font-size: 1rem;
-  line-height: 1.5;
-  border-radius: 0.25rem;
-  transition:
-    color 0.15s ease-in-out,
-    background-color 0.15s ease-in-out,
-    border-color 0.15s ease-in-out,
-    box-shadow 0.15s ease-in-out,
-    transform 0.15s ease-in-out;
-  text-decoration: none;
-}
-
-.btn-warning {
-  color: #212529;
-  background-color: #ffc107;
-  border-color: #ffc107;
-}
-
-.btn-warning:hover {
-  color: #212529;
-  background-color: #e0a800;
-  border-color: #d39e00;
-}
-
-.btn-danger {
-  color: #fff;
-  background-color: #dc3545;
-  border-color: #dc3545;
-}
-
-.btn-danger:hover {
-  color: #fff;
-  background-color: #c82333;
-  border-color: #bd2130;
-}
-
-.btn-credit {
-  color: #fff;
-  background-color: #6f42c1;
-  border-color: #6f42c1;
-}
-
-.btn-credit:hover {
-  color: #fff;
-  background-color: #5a32a3;
-  border-color: #4e2a8e;
-}
-
-.btn-info {
-  color: #fff;
-  background-color: #17a2b8;
-  border-color: #17a2b8;
-}
-
-.btn-info:hover {
-  color: #fff;
-  background-color: #138496;
-  border-color: #117a8b;
-}
-
-.nav-bar {
-  padding: 6px 10px;
-  height: auto;
-  width: fit-content;
-  max-width: 90%;
-  position: fixed;
-  bottom: 20px;
-  left: 50%;
-  transform: translateX(-50%);
+.tab-bar {
   display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  text-align: center;
-  z-index: 100;
-  border-radius: 18px;
-  background-color: var(--bg-glass, rgba(255, 255, 255, 0.6));
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  align-items: stretch;
+  gap: 4px;
+  padding: 6px 8px;
+  border-radius: 28px;
+  background: var(--bg-glass, rgba(255, 255, 255, 0.75));
+  backdrop-filter: saturate(180%) blur(20px);
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12),
+    0 1px 0 rgba(255, 255, 255, 0.4) inset;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+}
 
-  @media screen and (max-width: $mobile_BP_max_width) {
-    width: fit-content;
-    max-width: 95%;
-    bottom: 16px;
-    padding: 5px 8px;
-    gap: 6px;
+.tab {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  width: 64px;
+  padding: 6px 4px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  border-radius: 22px;
+  color: var(--text-primary, #2d3748);
+  transition:
+    color 0.2s ease,
+    background-color 0.2s ease,
+    transform 0.2s ease;
+  font: inherit;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.tab:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.tab.active {
+  color: #667eea;
+}
+
+.tab.active .tab-icon {
+  transform: scale(1.05);
+}
+
+.tab.active .tab-label {
+  font-weight: 700;
+}
+
+.tab-icon {
+  font-size: 20px;
+  transition: transform 0.2s ease;
+}
+
+.tab-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  white-space: nowrap;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@media screen and (max-width: $mobile_BP_max_width) {
+  .tab {
+    width: 58px;
   }
 
-  &.btn-group {
-    .btn {
-      margin: 0;
-      height: $navbar-height;
-      width: 3rem;
-      border: none;
-      transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-      font-size: 1.2rem;
-      font-weight: 600;
-      border-radius: 12px;
-      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
-
-      &:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-      }
-
-      &.active {
-        transform: translateY(-1px);
-        box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.9),
-          0 4px 12px rgba(0, 0, 0, 0.25);
-      }
-    }
+  .tab-icon {
+    font-size: 19px;
   }
 }
 </style>

--- a/front/src/components/NavBar.vue
+++ b/front/src/components/NavBar.vue
@@ -6,12 +6,15 @@
     aria-label="Navigation principale"
   >
     <button
-      v-if="!displayAccountList"
       type="button"
       class="tab tab-burger"
+      :class="{ active: displayAccountList }"
       :style="{ '--tab-color': '#4a5568' }"
-      aria-label="Ouvrir la liste des comptes"
-      @click="openAccountList"
+      :aria-label="displayAccountList
+        ? 'Fermer la liste des comptes'
+        : 'Ouvrir la liste des comptes'"
+      :aria-pressed="displayAccountList"
+      @click="toggleCompteList"
     >
       <font-awesome-icon
         class="tab-icon"
@@ -110,8 +113,8 @@
     }
   }
 
-  const openAccountList = () => {
-    store.dispatch('toggleAccountList', true)
+  const toggleCompteList = () => {
+    store.dispatch('toggleAccountList')
   }
 </script>
 

--- a/front/src/components/NavBar.vue
+++ b/front/src/components/NavBar.vue
@@ -6,6 +6,20 @@
     aria-label="Navigation principale"
   >
     <button
+      v-if="!displayAccountList"
+      type="button"
+      class="tab tab-burger"
+      :style="{ '--tab-color': '#4a5568' }"
+      aria-label="Ouvrir la liste des comptes"
+      @click="openAccountList"
+    >
+      <font-awesome-icon
+        class="tab-icon"
+        icon="hamburger"
+      />
+      <span class="tab-label">Comptes</span>
+    </button>
+    <button
       v-for="tab in tabs"
       :key="tab.path"
       type="button"
@@ -25,6 +39,7 @@
 </template>
 
 <script setup lang="ts">
+  import { computed } from 'vue'
   import { useRoute, useRouter } from 'vue-router'
   import { useStore } from 'vuex'
   import type { RouteLocationNormalizedLoaded } from 'vue-router'
@@ -32,6 +47,8 @@
   const route = useRoute()
   const router = useRouter()
   const store = useStore()
+
+  const displayAccountList = computed(() => store.state.display.account_list)
 
   type Tab = {
     label: string
@@ -91,6 +108,10 @@
     if (route.path !== path) {
       router.push(path)
     }
+  }
+
+  const openAccountList = () => {
+    store.dispatch('toggleAccountList', true)
   }
 </script>
 
@@ -163,6 +184,10 @@
   text-overflow: ellipsis;
 }
 
+.tab-burger {
+  display: none;
+}
+
 @media screen and (max-width: $mobile_BP_max_width) {
   .tab {
     width: 58px;
@@ -170,6 +195,10 @@
 
   .tab-icon {
     font-size: 19px;
+  }
+
+  .tab-burger {
+    display: flex;
   }
 }
 </style>

--- a/front/src/components/NavBar.vue
+++ b/front/src/components/NavBar.vue
@@ -125,12 +125,10 @@
   gap: 4px;
   padding: 6px 8px;
   border-radius: 28px;
-  background: var(--bg-dock, rgba(255, 255, 255, 0.55));
-  backdrop-filter: saturate(180%) blur(20px);
-  -webkit-backdrop-filter: saturate(180%) blur(20px);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12),
-    0 1px 0 rgba(255, 255, 255, 0.4) inset;
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 .tab {

--- a/front/src/components/NavBar.vue
+++ b/front/src/components/NavBar.vue
@@ -1,25 +1,23 @@
 <template>
-  <nav
+  <div
     v-if="route.name !== 'Login'"
-    class="tab-bar"
-    role="navigation"
+    class="nav-bar btn-group"
+    role="group"
     aria-label="Navigation principale"
   >
     <button
       v-for="tab in tabs"
       :key="tab.path"
       type="button"
-      class="tab"
-      :class="{ active: tab.match(route) }"
+      class="btn"
+      :class="[tab.colorClass, { active: tab.match(route) }]"
+      :aria-label="tab.label"
+      :aria-current="tab.match(route) ? 'page' : undefined"
       @click="goTo(tab.path)"
     >
-      <font-awesome-icon
-        class="tab-icon"
-        :icon="tab.icon"
-      />
-      <span class="tab-label">{{ tab.label }}</span>
+      <font-awesome-icon :icon="tab.icon" />
     </button>
-  </nav>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -35,34 +33,53 @@
     label: string
     icon: string
     path: string
+    colorClass: string
     match: (r: RouteLocationNormalizedLoaded) => boolean
   }
 
-  const gestionPaths = ['/gestion', '/credits', '/biens', '/recurrOperation', '/amortissement']
-  const settingsPaths = ['/config', '/editUser']
+  const isGestionRoute = (r: RouteLocationNormalizedLoaded) => {
+    const p = r.path
+    return (
+      p === '/gestion' ||
+      p === '/credits' || p === '/newCredit' || p.startsWith('/editCredit') ||
+      p === '/biens' || p === '/newBien' || p.startsWith('/editBien') ||
+      p === '/recurrOperation' || p === '/newRecurrOperation' || p.startsWith('/editRecurrOperation') ||
+      p === '/amortissement'
+    )
+  }
 
-  const isHomeRoute = (r: RouteLocationNormalizedLoaded) =>
-    r.path === '/' ||
-    r.path === '/newOperation' ||
-    r.path.startsWith('/editOperation') ||
-    r.path === '/search' ||
-    r.path === '/transfert' ||
-    r.path === '/retrait'
-
-  const isGestionRoute = (r: RouteLocationNormalizedLoaded) =>
-    gestionPaths.some((p) => r.path === p || r.path.startsWith(p + '/')) ||
-    r.path === '/newRecurrOperation' ||
-    r.path.startsWith('/editRecurrOperation') ||
-    r.path === '/newCredit' ||
-    r.path.startsWith('/editCredit') ||
-    r.path === '/newBien' ||
-    r.path.startsWith('/editBien')
+  const isSettingsRoute = (r: RouteLocationNormalizedLoaded) =>
+    r.path === '/config' || r.path === '/editUser'
 
   const tabs: Tab[] = [
-    { label: 'Comptes', icon: 'wallet', path: '/', match: isHomeRoute },
-    { label: 'Gestion', icon: 'building', path: '/gestion', match: isGestionRoute },
-    { label: 'Stats', icon: 'chart-pie', path: '/stats', match: (r) => r.path === '/stats' },
-    { label: 'Réglages', icon: 'cogs', path: '/config', match: (r) => settingsPaths.includes(r.path) }
+    {
+      label: 'Recherche',
+      icon: 'search',
+      path: '/search',
+      colorClass: 'btn-info',
+      match: (r) => r.path === '/search'
+    },
+    {
+      label: 'Gestion',
+      icon: 'building',
+      path: '/gestion',
+      colorClass: 'btn-credit',
+      match: isGestionRoute
+    },
+    {
+      label: 'Stats',
+      icon: 'chart-pie',
+      path: '/stats',
+      colorClass: 'btn-warning',
+      match: (r) => r.path === '/stats'
+    },
+    {
+      label: 'Réglages',
+      icon: 'cogs',
+      path: '/config',
+      colorClass: 'btn-danger',
+      match: isSettingsRoute
+    }
   ]
 
   const goTo = (path: string) => {
@@ -74,61 +91,137 @@
 </script>
 
 <style lang="scss" scoped>
-.tab-bar {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: $navbar-height;
-  padding-bottom: env(safe-area-inset-bottom, 0px);
-  background: var(--bg-glass, rgba(255, 255, 255, 0.95));
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border-top: 1px solid var(--border-color, rgba(0, 0, 0, 0.08));
-  display: flex;
-  justify-content: space-around;
-  align-items: stretch;
-  z-index: 100;
-  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.05);
-}
-
-.tab {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  padding: 6px 4px;
-  background: transparent;
-  border: none;
+.btn {
+  display: inline-block;
+  font-weight: 400;
+  color: #fff;
+  text-align: center;
+  vertical-align: middle;
   cursor: pointer;
-  color: var(--text-secondary, #a0aec0);
-  transition: color 0.2s ease, transform 0.2s ease;
-  font: inherit;
-  -webkit-tap-highlight-color: transparent;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  background-color: transparent;
+  border: 1px solid transparent;
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  border-radius: 0.25rem;
+  transition:
+    color 0.15s ease-in-out,
+    background-color 0.15s ease-in-out,
+    border-color 0.15s ease-in-out,
+    box-shadow 0.15s ease-in-out,
+    transform 0.15s ease-in-out;
+  text-decoration: none;
 }
 
-.tab:hover {
-  color: var(--text-primary, #4a5568);
+.btn-warning {
+  color: #212529;
+  background-color: #ffc107;
+  border-color: #ffc107;
 }
 
-.tab.active {
-  color: var(--primary-color, #667eea);
+.btn-warning:hover {
+  color: #212529;
+  background-color: #e0a800;
+  border-color: #d39e00;
 }
 
-.tab.active .tab-icon {
-  transform: scale(1.1);
+.btn-danger {
+  color: #fff;
+  background-color: #dc3545;
+  border-color: #dc3545;
 }
 
-.tab-icon {
-  font-size: 20px;
-  transition: transform 0.2s ease;
+.btn-danger:hover {
+  color: #fff;
+  background-color: #c82333;
+  border-color: #bd2130;
 }
 
-.tab-label {
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.2px;
+.btn-credit {
+  color: #fff;
+  background-color: #6f42c1;
+  border-color: #6f42c1;
+}
+
+.btn-credit:hover {
+  color: #fff;
+  background-color: #5a32a3;
+  border-color: #4e2a8e;
+}
+
+.btn-info {
+  color: #fff;
+  background-color: #17a2b8;
+  border-color: #17a2b8;
+}
+
+.btn-info:hover {
+  color: #fff;
+  background-color: #138496;
+  border-color: #117a8b;
+}
+
+.nav-bar {
+  padding: 8px 16px;
+  height: auto;
+  width: fit-content;
+  max-width: 90%;
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  text-align: center;
+  z-index: 100;
+  border-radius: 14px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+  backdrop-filter: blur(5px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+
+  @media screen and (max-width: $mobile_BP_max_width) {
+    width: fit-content;
+    max-width: 95%;
+    bottom: 16px;
+    padding: 6px 12px;
+  }
+
+  &.btn-group {
+    .btn {
+      margin: 0;
+      height: $navbar-height;
+      width: 3rem;
+      border: none;
+      backdrop-filter: blur(5px);
+      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+      font-size: 1.2rem;
+      font-weight: 600;
+      border-radius: 0;
+
+      &:first-child {
+        border-top-left-radius: 14px;
+        border-bottom-left-radius: 14px;
+      }
+
+      &:last-child {
+        border-top-right-radius: 14px;
+        border-bottom-right-radius: 14px;
+      }
+
+      &:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+      }
+
+      &.active {
+        transform: translateY(-1px);
+        box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.85),
+          0 4px 12px rgba(0, 0, 0, 0.25);
+      }
+    }
+  }
 }
 </style>

--- a/front/src/components/NavBar.vue
+++ b/front/src/components/NavBar.vue
@@ -196,16 +196,12 @@
   }
 
   .tab {
-    width: 54px;
+    width: 56px;
     padding: 5px 2px;
   }
 
   .tab-icon {
     font-size: 19px;
-  }
-
-  .tab-label {
-    font-size: 9px;
   }
 
   .tab-burger {

--- a/front/src/components/OperationForm.vue
+++ b/front/src/components/OperationForm.vue
@@ -137,7 +137,7 @@
               for="Amortissement"
             >
               <span class="checkbox-custom" />
-              Amortissement
+              Coûts d'usage
             </label>
           </div>
         </div>

--- a/front/src/components/OperationList.vue
+++ b/front/src/components/OperationList.vue
@@ -43,7 +43,7 @@
   const operationsOfActiveAccount = computed(
     () => store.state.operation.operationsOfActiveAccount
   )
-  const hasMoreOperations = computed(() => store.state.operation.hasMoreOperations && activeAccount.value.NomCompte !== 'Amortissement')
+  const hasMoreOperations = computed(() => store.state.operation.hasMoreOperations && activeAccount.value.NomCompte !== "Coûts d'usage")
   const isLoadingOperations = computed(() => store.state.operation.isLoadingOperations)
   const isSearchMode = computed(() => store.state.operation.isSearchMode)
 

--- a/front/src/router.ts
+++ b/front/src/router.ts
@@ -7,6 +7,7 @@ const Config = () => import(/* webpackChunkName: "config" */ './views/Config.vue
 const EditUser = () => import(/* webpackChunkName: "edituser" */ './views/EditUser.vue')
 const OperationsRecurrentes = () => import(/* webpackChunkName: "operecur" */ './views/OperationsRecurrentes.vue')
 const Amortissement = () => import(/* webpackChunkName: "operecur" */ './views/Amortissement.vue')
+const Gestion = () => import(/* webpackChunkName: "gestion" */ './views/Gestion.vue')
 const Credits = () => import(/* webpackChunkName: "credits" */ './views/Credits.vue')
 const Biens = () => import(/* webpackChunkName: "biens" */ './views/Biens.vue')
 const RouteOverTheContent = () => import(/* webpackChunkName: "othercontent" */ './views/RouteOverTheContent.vue')
@@ -79,6 +80,13 @@ export default createRouter({
     path: '/amortissement',
     name: 'Amortissement',
     component: Amortissement,
+    meta: {
+      disabledTotalHeader: true
+    }
+  }, {
+    path: '/gestion',
+    name: 'Gestion',
+    component: Gestion,
     meta: {
       disabledTotalHeader: true
     }

--- a/front/src/store/operation.ts
+++ b/front/src/store/operation.ts
@@ -160,9 +160,6 @@ export default {
     },
 
     fetchRecurrOperation ({ rootState, commit }) {
-      commit('setOperationsOfActiveAccount', {})
-      commit('setActiveAccount', { NomCompte: 'Opérations récurrentes' })
-
       fetchRecurrOperation(
         rootState.user.token,
         window.env.VITE_API_URL

--- a/front/src/styles/theme.css
+++ b/front/src/styles/theme.css
@@ -34,6 +34,7 @@
   --bg-muted: #f1f5f9;
   --bg-glass: rgba(255, 255, 255, 0.95);
   --bg-glass-dark: rgba(255, 255, 255, 0.8);
+  --bg-dock: rgba(255, 255, 255, 0.55);
   --bg-overlay: rgba(0, 0, 0, 0.25);
   --bg-overlay-light: rgba(0, 0, 0, 0.05);
   --bg-overlay-medium: rgba(0, 0, 0, 0.075);
@@ -211,7 +212,8 @@
     --bg-muted: #4a5568;
     --bg-glass: rgba(45, 55, 72, 0.95);
     --bg-glass-dark: rgba(45, 55, 72, 0.8);
-    
+    --bg-dock: rgba(45, 55, 72, 0.55);
+
     /* Bordures adaptées */
     --border-color: #4a5568;
     --border-color-light: #2d3748;
@@ -260,7 +262,8 @@ html.light-theme {
   --bg-muted: #f1f5f9;
   --bg-glass: rgba(255, 255, 255, 0.95);
   --bg-glass-dark: rgba(255, 255, 255, 0.8);
-  
+  --bg-dock: rgba(255, 255, 255, 0.55);
+
   --border-color: #e2e8f0;
   --border-color-light: #f1f5f9;
   --border-color-input: #ced4da;
@@ -298,7 +301,8 @@ html.dark-theme {
   --bg-muted: #4a5568;
   --bg-glass: rgba(45, 55, 72, 0.95);
   --bg-glass-dark: rgba(45, 55, 72, 0.8);
-  
+  --bg-dock: rgba(45, 55, 72, 0.55);
+
   --border-color: #4a5568;
   --border-color-light: #2d3748;
   --border-color-input: #4a5568;

--- a/front/src/styles/variables.scss
+++ b/front/src/styles/variables.scss
@@ -4,5 +4,5 @@ $mobile_BP_max_width: 767px;
 $header-height: 70px;
 $header-height-and-margin: 80px;
 $left-panel-width: 33%;
-$navbar-height: 40px;
-$navbar-height-and-margin: 70px;
+$navbar-height: 64px;
+$navbar-height-and-margin: 84px;

--- a/front/src/styles/variables.scss
+++ b/front/src/styles/variables.scss
@@ -4,5 +4,5 @@ $mobile_BP_max_width: 767px;
 $header-height: 70px;
 $header-height-and-margin: 80px;
 $left-panel-width: 33%;
-$navbar-height: 64px;
-$navbar-height-and-margin: 84px;
+$navbar-height: 40px;
+$navbar-height-and-margin: 70px;

--- a/front/src/views/Amortissement.vue
+++ b/front/src/views/Amortissement.vue
@@ -14,7 +14,7 @@
   store.dispatch('fetchOperations', {
     amortissement: 1
   })
-  store.commit('setActiveAccount', { NomCompte: 'Amortissement' })
+  store.commit('setActiveAccount', { NomCompte: "Coûts d'usage" })
 </script>
 
 <style lang="scss" scoped>

--- a/front/src/views/Gestion.vue
+++ b/front/src/views/Gestion.vue
@@ -23,50 +23,6 @@
       <button
         type="button"
         class="gestion-card"
-        @click="goTo('/biens')"
-      >
-        <div class="gestion-icon icon-bien">
-          <font-awesome-icon icon="home" />
-        </div>
-        <div class="gestion-label">
-          Biens
-        </div>
-        <div class="gestion-count">
-          {{ biensCount }} bien{{ biensCount > 1 ? 's' : '' }}
-        </div>
-        <div
-          v-if="totalBiens > 0"
-          class="gestion-amount"
-        >
-          <Currency :amount="totalBiens" />
-        </div>
-      </button>
-
-      <button
-        type="button"
-        class="gestion-card"
-        @click="goTo('/credits')"
-      >
-        <div class="gestion-icon icon-credit">
-          <font-awesome-icon icon="credit-card" />
-        </div>
-        <div class="gestion-label">
-          Crédits
-        </div>
-        <div class="gestion-count">
-          {{ creditsCount }} actif{{ creditsCount > 1 ? 's' : '' }}
-        </div>
-        <div
-          v-if="totalCreditsRemaining > 0"
-          class="gestion-amount neg"
-        >
-          <Currency :amount="-totalCreditsRemaining" />
-        </div>
-      </button>
-
-      <button
-        type="button"
-        class="gestion-card"
         @click="goTo('/recurrOperation')"
       >
         <div class="gestion-icon icon-recur">
@@ -95,18 +51,67 @@
           Suivi des achats
         </div>
       </button>
+
+      <button
+        type="button"
+        class="gestion-card"
+        @click="goTo('/credits')"
+      >
+        <div class="gestion-icon icon-credit">
+          <font-awesome-icon icon="credit-card" />
+        </div>
+        <div class="gestion-label">
+          Crédits
+        </div>
+        <div class="gestion-count">
+          {{ creditsCount }} actif{{ creditsCount > 1 ? 's' : '' }}
+        </div>
+        <div
+          v-if="totalCreditsRemaining > 0"
+          class="gestion-amount neg"
+        >
+          <Currency :amount="-totalCreditsRemaining" />
+        </div>
+      </button>
+
+      <button
+        type="button"
+        class="gestion-card"
+        @click="goTo('/biens')"
+      >
+        <div class="gestion-icon icon-bien">
+          <font-awesome-icon icon="home" />
+        </div>
+        <div class="gestion-label">
+          Biens
+        </div>
+        <div class="gestion-count">
+          {{ biensCount }} bien{{ biensCount > 1 ? 's' : '' }}
+        </div>
+        <div
+          v-if="totalBiens > 0"
+          class="gestion-amount"
+        >
+          <Currency :amount="totalBiens" />
+        </div>
+      </button>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-  import { computed, onMounted } from 'vue'
+  import { computed } from 'vue'
   import { useRouter } from 'vue-router'
   import { useStore } from 'vuex'
   import Currency from '@/components/Currency.vue'
 
   const store = useStore()
   const router = useRouter()
+
+  store.commit('setActiveAccount', { NomCompte: 'Gestion' })
+  store.dispatch('fetchBiens')
+  store.dispatch('fetchCredits')
+  store.dispatch('fetchRecurrOperation')
 
   const biens = computed(() => store.state.bien.bienList || [])
   const credits = computed(() => store.state.credit.creditList || [])
@@ -142,13 +147,6 @@
   const goTo = (path: string) => {
     router.push(path)
   }
-
-  onMounted(() => {
-    store.commit('setActiveAccount', { NomCompte: 'Gestion' })
-    store.dispatch('fetchBiens')
-    store.dispatch('fetchCredits')
-    store.dispatch('fetchRecurrOperation')
-  })
 </script>
 
 <style lang="scss" scoped>

--- a/front/src/views/Gestion.vue
+++ b/front/src/views/Gestion.vue
@@ -1,0 +1,278 @@
+<template>
+  <div class="gestion-view">
+    <div class="patrimoine-header">
+      <div class="patrimoine-header-top">
+        <span class="patrimoine-title">Patrimoine total</span>
+      </div>
+      <div class="patrimoine-balance">
+        <Currency :amount="patrimoineTotal" />
+      </div>
+      <div
+        v-if="biensCount > 0 || creditsCount > 0"
+        class="patrimoine-meta"
+      >
+        {{ biensCount }} bien{{ biensCount > 1 ? 's' : '' }} ·
+        {{ creditsCount }} crédit{{ creditsCount > 1 ? 's' : '' }}
+      </div>
+    </div>
+
+    <div class="section-title">
+      Mes outils
+    </div>
+    <div class="gestion-grid">
+      <button
+        type="button"
+        class="gestion-card"
+        @click="goTo('/biens')"
+      >
+        <div class="gestion-icon icon-bien">
+          <font-awesome-icon icon="home" />
+        </div>
+        <div class="gestion-label">
+          Biens
+        </div>
+        <div class="gestion-count">
+          {{ biensCount }} bien{{ biensCount > 1 ? 's' : '' }}
+        </div>
+        <div
+          v-if="totalBiens > 0"
+          class="gestion-amount"
+        >
+          <Currency :amount="totalBiens" />
+        </div>
+      </button>
+
+      <button
+        type="button"
+        class="gestion-card"
+        @click="goTo('/credits')"
+      >
+        <div class="gestion-icon icon-credit">
+          <font-awesome-icon icon="credit-card" />
+        </div>
+        <div class="gestion-label">
+          Crédits
+        </div>
+        <div class="gestion-count">
+          {{ creditsCount }} actif{{ creditsCount > 1 ? 's' : '' }}
+        </div>
+        <div
+          v-if="totalCreditsRemaining > 0"
+          class="gestion-amount neg"
+        >
+          <Currency :amount="-totalCreditsRemaining" />
+        </div>
+      </button>
+
+      <button
+        type="button"
+        class="gestion-card"
+        @click="goTo('/recurrOperation')"
+      >
+        <div class="gestion-icon icon-recur">
+          <font-awesome-icon icon="retweet" />
+        </div>
+        <div class="gestion-label">
+          Récurrentes
+        </div>
+        <div class="gestion-count">
+          {{ recurringCount }} opération{{ recurringCount > 1 ? 's' : '' }}
+        </div>
+      </button>
+
+      <button
+        type="button"
+        class="gestion-card"
+        @click="goTo('/amortissement')"
+      >
+        <div class="gestion-icon icon-amort">
+          <font-awesome-icon icon="history" />
+        </div>
+        <div class="gestion-label">
+          Coûts d'usage
+        </div>
+        <div class="gestion-count">
+          Suivi des achats
+        </div>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { computed, onMounted } from 'vue'
+  import { useRouter } from 'vue-router'
+  import { useStore } from 'vuex'
+  import Currency from '@/components/Currency.vue'
+
+  const store = useStore()
+  const router = useRouter()
+
+  const biens = computed(() => store.state.bien.bienList || [])
+  const credits = computed(() => store.state.credit.creditList || [])
+  const creditBalances = computed(() => store.state.credit.creditBalances || {})
+  const recurringOperations = computed(
+    () => store.state.operation.recurringOperations || []
+  )
+
+  const biensCount = computed(() => biens.value.length)
+  const creditsCount = computed(() => credits.value.length)
+  const recurringCount = computed(() => recurringOperations.value.length)
+
+  const totalBiens = computed(() =>
+    biens.value.reduce((sum, b) => {
+      const value =
+        b.ValeurActuelle ??
+        (b.PrixBienNu || 0) + (b.FraisNotaire || 0) + (b.FraisAgence || 0)
+      return sum + value
+    }, 0)
+  )
+
+  const totalCreditsRemaining = computed(() =>
+    credits.value.reduce((sum, c) => {
+      const balance = creditBalances.value[c.IDcredit]
+      return sum + (balance?.solde ?? c.MontantInitial ?? 0)
+    }, 0)
+  )
+
+  const patrimoineTotal = computed(
+    () => totalBiens.value - totalCreditsRemaining.value
+  )
+
+  const goTo = (path: string) => {
+    router.push(path)
+  }
+
+  onMounted(() => {
+    store.commit('setActiveAccount', { NomCompte: 'Gestion' })
+    store.dispatch('fetchBiens')
+    store.dispatch('fetchCredits')
+    store.dispatch('fetchRecurrOperation')
+  })
+</script>
+
+<style lang="scss" scoped>
+.gestion-view {
+  min-height: calc(100vh - #{$header-height-and-margin});
+  padding: 0 16px calc(#{$navbar-height-and-margin} + 24px);
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.patrimoine-header {
+  background: var(--primary-gradient, linear-gradient(135deg, #667eea 0%, #764ba2 100%));
+  color: #fff;
+  border-radius: 16px;
+  padding: 20px 24px;
+  margin-top: 8px;
+  box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.1));
+}
+
+.patrimoine-header-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+  font-size: 14px;
+  opacity: 0.9;
+}
+
+.patrimoine-balance {
+  font-size: 30px;
+  font-weight: 700;
+  letter-spacing: -0.5px;
+}
+
+.patrimoine-meta {
+  font-size: 12px;
+  opacity: 0.85;
+  margin-top: 6px;
+}
+
+.section-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-secondary, #4a5568);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 20px 4px 10px;
+}
+
+.gestion-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+@media (min-width: $desktop_BP_min_width) {
+  .gestion-grid {
+    grid-template-columns: repeat(4, 1fr);
+    gap: 16px;
+  }
+}
+
+.gestion-card {
+  background: var(--bg-card, #fff);
+  border: var(--card-border, 1px solid rgba(0, 0, 0, 0.05));
+  border-radius: 16px;
+  padding: 20px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  box-shadow: var(--shadow-sm, 0 2px 8px rgba(0, 0, 0, 0.06));
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  text-align: center;
+  font: inherit;
+  color: inherit;
+}
+
+.gestion-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md, 0 8px 16px rgba(0, 0, 0, 0.1));
+}
+
+.gestion-card:active {
+  transform: translateY(0);
+}
+
+.gestion-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 22px;
+  margin-bottom: 6px;
+}
+
+.icon-bien { background: linear-gradient(135deg, #e83e8c 0%, #c42a60 100%); }
+.icon-credit { background: linear-gradient(135deg, #6f42c1 0%, #4e2a8e 100%); }
+.icon-recur { background: linear-gradient(135deg, #17a2b8 0%, #117a8b 100%); }
+.icon-amort { background: linear-gradient(135deg, #28a745 0%, #1e7e34 100%); }
+
+.gestion-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary, #2d3748);
+}
+
+.gestion-count {
+  font-size: 12px;
+  color: var(--text-secondary, #a0aec0);
+}
+
+.gestion-amount {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-primary, #2d3748);
+  margin-top: 4px;
+}
+
+.gestion-amount.neg {
+  color: #e53e3e;
+}
+</style>

--- a/front/src/views/OperationsRecurrentes.vue
+++ b/front/src/views/OperationsRecurrentes.vue
@@ -12,6 +12,9 @@
 
   const store = useStore()
 
+  store.commit('setOperationsOfActiveAccount', [])
+  store.commit('setActiveAccount', { NomCompte: 'Opérations récurrentes' })
+
   const userToken = computed(() => store.state.user.token)
   const operationsOfActiveAccount = computed(
     () => store.state.operation.operationsOfActiveAccount

--- a/mockups/option-3-bottom-tabs-fab.html
+++ b/mockups/option-3-bottom-tabs-fab.html
@@ -333,7 +333,7 @@
 </head>
 <body>
   <h1>Option 3 — Bottom tabs + Floating Action Button</h1>
-  <p class="subtitle">3 écrans : navigation par onglets · FAB déployé · Vue Patrimoine</p>
+  <p class="subtitle">3 écrans : navigation par onglets · FAB déployé · Vue Gestion</p>
 
   <div class="phones">
 
@@ -415,7 +415,7 @@
           </div>
           <div class="tab">
             <i class="fas fa-building"></i>
-            <span>Patrimoine</span>
+            <span>Gestion</span>
           </div>
           <div class="tab">
             <i class="fas fa-chart-pie"></i>
@@ -497,7 +497,7 @@
           </div>
           <div class="tab">
             <i class="fas fa-building"></i>
-            <span>Patrimoine</span>
+            <span>Gestion</span>
           </div>
           <div class="tab">
             <i class="fas fa-chart-pie"></i>
@@ -511,9 +511,9 @@
       </div>
     </div>
 
-    <!-- ===== PHONE 3 : Patrimoine ===== -->
+    <!-- ===== PHONE 3 : Gestion ===== -->
     <div class="phone-wrapper">
-      <div class="phone-label">3. Onglet Patrimoine — hub</div>
+      <div class="phone-label">3. Onglet Gestion — hub</div>
       <div class="phone">
         <div class="status-bar">
           <span>9:41</span>
@@ -561,13 +561,13 @@
               <div class="patrimoine-icon pi-amort">
                 <i class="fas fa-history"></i>
               </div>
-              <div class="patrimoine-label">Amortissement</div>
+              <div class="patrimoine-label">Coûts d'usage</div>
               <div class="patrimoine-count">Suivi 2026</div>
             </div>
           </div>
         </div>
 
-        <!-- FAB - contextuel pour Patrimoine -->
+        <!-- FAB - contextuel pour Gestion -->
         <div class="fab-container">
           <button class="fab"><i class="fas fa-plus"></i></button>
         </div>
@@ -580,7 +580,7 @@
           </div>
           <div class="tab active">
             <i class="fas fa-building"></i>
-            <span>Patrimoine</span>
+            <span>Gestion</span>
           </div>
           <div class="tab">
             <i class="fas fa-chart-pie"></i>
@@ -599,15 +599,15 @@
   <div class="description">
     <h2>Ce que change ce design</h2>
     <ul>
-      <li><strong>4 onglets de navigation</strong> en bas, fixes : <em>Comptes</em>, <em>Patrimoine</em>, <em>Stats</em>, <em>Réglages</em>. Plus on ajoute de fonctionnalités, plus on les regroupe sous un onglet — la navbar n'enfle plus jamais.</li>
-      <li><strong>Un FAB rond en bas à droite</strong> pour les actions de création. Il est <em>contextuel</em> : sur Comptes il propose Opération / Virement / Recherche ; sur Patrimoine il proposera Bien / Crédit / Récurrente.</li>
-      <li><strong>Onglet Patrimoine = hub visuel</strong> avec une grille de cartes (Biens, Crédits, Récurrentes, Amortissement). Chaque carte affiche un compteur ou un total. C'est plus découvrable qu'une liste de boutons.</li>
+      <li><strong>4 onglets de navigation</strong> en bas, fixes : <em>Comptes</em>, <em>Gestion</em>, <em>Stats</em>, <em>Réglages</em>. Plus on ajoute de fonctionnalités, plus on les regroupe sous un onglet — la navbar n'enfle plus jamais.</li>
+      <li><strong>Un FAB rond en bas à droite</strong> pour les actions de création. Il est <em>contextuel</em> : sur Comptes il propose Opération / Virement / Recherche ; sur Gestion il proposera Bien / Crédit / Récurrente.</li>
+      <li><strong>Onglet Gestion = hub visuel</strong> avec une grille de cartes (Biens, Crédits, Récurrentes, Coûts d'usage). Chaque carte affiche un compteur ou un total. C'est plus découvrable qu'une liste de boutons.</li>
       <li><strong>Le hamburger disparaît</strong> sur mobile : la liste des comptes peut basculer en horizontal scrollable au-dessus des opérations, ou rester en panneau swipeable mais sans bouton dédié (geste seul).</li>
     </ul>
     <h2 style="margin-top: 24px;">Effort d'implémentation</h2>
     <ul>
       <li>Refonte de <code>NavBar.vue</code> (tab bar) + nouveau composant <code>FabMenu.vue</code> (speed-dial)</li>
-      <li>Nouvelle vue <code>Patrimoine.vue</code> qui sert de hub + ajustement des routes (les 4 vues actuelles deviennent enfants)</li>
+      <li>Nouvelle vue <code>Gestion.vue</code> qui sert de hub + ajustement des routes (les 4 vues actuelles deviennent enfants)</li>
       <li>Adaptation du layout dans <code>App.vue</code> pour le panneau gauche</li>
       <li>Pas de changement backend</li>
     </ul>

--- a/mockups/option-3-desktop-ipad.html
+++ b/mockups/option-3-desktop-ipad.html
@@ -381,7 +381,7 @@
             </div>
             <div class="rail-tab">
               <i class="fas fa-building"></i>
-              <span>Patrimoine</span>
+              <span>Gestion</span>
             </div>
             <div class="rail-tab">
               <i class="fas fa-chart-pie"></i>
@@ -573,7 +573,7 @@
             </div>
             <div class="rail-tab">
               <i class="fas fa-building"></i>
-              <span>Patrimoine</span>
+              <span>Gestion</span>
             </div>
             <div class="rail-tab">
               <i class="fas fa-chart-pie"></i>
@@ -693,9 +693,9 @@
       </div>
     </div>
 
-    <!-- ========== ÉCRAN 3 : Patrimoine ========== -->
+    <!-- ========== ÉCRAN 3 : Gestion ========== -->
     <div class="screen-wrapper">
-      <div class="screen-label">3. Onglet Patrimoine — hub avec cartes et résumé</div>
+      <div class="screen-label">3. Onglet Gestion — hub avec cartes et résumé</div>
       <div class="ipad">
         <div class="layout">
 
@@ -707,7 +707,7 @@
             </div>
             <div class="rail-tab active">
               <i class="fas fa-building"></i>
-              <span>Patrimoine</span>
+              <span>Gestion</span>
             </div>
             <div class="rail-tab">
               <i class="fas fa-chart-pie"></i>
@@ -721,12 +721,12 @@
             <div class="rail-user">JX</div>
           </div>
 
-          <!-- Pas de panneau "comptes" sur l'onglet Patrimoine : la zone main occupe toute la largeur restante -->
+          <!-- Pas de panneau "comptes" sur l'onglet Gestion : la zone main occupe toute la largeur restante -->
           <div class="main">
             <div class="main-header">
               <div class="mh-left">
                 <div class="mh-title">Vue d'ensemble</div>
-                <div class="mh-account">Patrimoine</div>
+                <div class="mh-account">Gestion</div>
                 <div class="mh-balance">412 580 €</div>
               </div>
               <div class="mh-right">
@@ -796,14 +796,14 @@
                 <div class="pat-card">
                   <div class="pat-icon pi-amort"><i class="fas fa-history"></i></div>
                   <div class="pat-arrow"><i class="fas fa-chevron-right"></i></div>
-                  <div class="pat-label">Amortissement</div>
+                  <div class="pat-label">Coûts d'usage</div>
                   <div class="pat-count">Suivi 2026</div>
                   <div class="pat-amount">62 350 € remboursé</div>
                 </div>
               </div>
             </div>
 
-            <!-- FAB contextuel : sur Patrimoine, le + ouvre les créations Bien/Crédit/Récurrente -->
+            <!-- FAB contextuel : sur Gestion, le + ouvre les créations Bien/Crédit/Récurrente -->
             <div class="fab-container">
               <button class="fab"><i class="fas fa-plus"></i></button>
             </div>
@@ -821,7 +821,7 @@
       <li><strong>Rail vertical fixe à gauche</strong> (84 px) : remplace la barre du bas du mobile. Les 4 onglets sont toujours visibles avec un indicateur lumineux sur l'onglet actif. Le rail est sombre pour faire respirer la zone de contenu.</li>
       <li><strong>Trois colonnes sur l'onglet Comptes</strong> : rail · liste des comptes (300 px) · contenu principal. La liste des comptes apparaît uniquement quand elle est pertinente — sur les autres onglets, le contenu principal s'étale sur toute la largeur.</li>
       <li><strong>Tableau d'opérations enrichi</strong> : sur grand écran on tire parti de la largeur (date · icône · nom · catégorie · montant · check · menu). Sur mobile, ces colonnes s'empilent comme aujourd'hui.</li>
-      <li><strong>Hub Patrimoine</strong> : un header avec patrimoine total et plus-value, 4 cartes de KPI en haut (valeur immo, capital remboursé, mensualités totales, cash-flow locatif) puis la grille des 4 outils. C'est la vue qui justifie le mieux le mode paysage.</li>
+      <li><strong>Hub Gestion</strong> : un header avec patrimoine total et plus-value, 4 cartes de KPI en haut (valeur immo, capital remboursé, mensualités totales, cash-flow locatif) puis la grille des 4 outils. C'est la vue qui justifie le mieux le mode paysage.</li>
       <li><strong>FAB en bas-droite du contenu</strong>, pas de l'écran : il se positionne dans la zone qu'il commande. Speed-dial avec labels textuels (le hover desktop donne plus de place qu'un long-press mobile).</li>
       <li><strong>Avatar utilisateur</strong> en bas du rail : remplace le bouton réglages discret + permet de switcher d'utilisateur ou se déconnecter.</li>
     </ul>
@@ -829,7 +829,7 @@
     <ul>
       <li><code>NavRail.vue</code> (desktop) + <code>BottomTabs.vue</code> (mobile) qui partagent le même contrat de tabs</li>
       <li><code>FabMenu.vue</code> avec slot pour mini-actions contextuelles à chaque vue</li>
-      <li><code>Patrimoine.vue</code> : nouvelle vue hub, KPI calculés à partir des stores existants <code>credit</code> et <code>bien</code></li>
+      <li><code>Gestion.vue</code> : nouvelle vue hub, KPI calculés à partir des stores existants <code>credit</code> et <code>bien</code></li>
       <li>Ajustement de <code>App.vue</code> : layout en grid (rail / accounts / main) plutôt qu'en flex avec navbar bottom</li>
     </ul>
   </div>


### PR DESCRIPTION
## Résumé

Refonte de la navigation et du vocabulaire de l'app pour faire émerger une vraie section **Gestion** qui regroupe les outils long-terme (récurrentes, coûts d'usage, crédits, biens), accessible depuis un dock flottant inspiré d'iOS 26.

## Changements

### Renommages

- `Amortissement` → **Coûts d'usage** (libellé visible uniquement : route, fichiers, classes CSS et champ DB `amortissement` restent inchangés pour ne rien casser).
- Section `Patrimoine` (proposée dans les mockups) → **Gestion** dans les mockups et dans toute la nouvelle UI.

### Nouvelle vue `Gestion.vue` (`/gestion`)

Hub centralisant les outils. Affiche :

- un header « Patrimoine total » calculé à partir de la valeur des biens (`ValeurActuelle` ou prix d'achat + frais) moins le restant à rembourser des crédits,
- une grille de 4 cartes cliquables dans l'ordre **Récurrentes → Coûts d'usage → Crédits → Biens**, chacune avec son icône colorée, son compteur et son montant agrégé.

`setActiveAccount({ NomCompte: 'Gestion' })` est appelé synchroniquement pour que le header affiche immédiatement « Gestion ».

### Nouveau dock flottant

Refonte complète de `NavBar.vue` + nouveau composant `FabMenu.vue`, regroupés dans `App.vue` au sein d'un wrapper `.bottom-dock` (`position: fixed; bottom: 15px; left: 50%`).

- **Pill NavBar** : style liquid-glass (transparent + `backdrop-filter: blur(5px)` + bordure blanche, identique au fond de `main`). 4 onglets avec icône + libellé en colonne, chacun avec sa couleur (Recherche cyan, Gestion violet, Stats jaune, Réglages rouge). L'onglet actif a un fond teinté de sa couleur et un libellé en gras.
- **Burger « Comptes »** : tab supplémentaire en tête de la pill, visible uniquement sur mobile (la `CompteList` est permanente sur desktop). Toggle qui ouvre / referme le panneau de gauche.
- **FAB** : bouton rond glass à droite du pill. Toujours visible mais désactivé (opacity 0.45) quand aucune action n'est dispo dans le contexte courant. Le `+` pivote en `×` à l'ouverture (animation préservée même au survol).
- **Mini-fabs contextuels** au-dessus du FAB :
  - sur Comptes : Nouvelle opération, Virement
  - sur Gestion / sous-vues : Nouveau bien, Nouveau crédit, Nouvelle récurrente
- **Backdrop** téléporté dans `<body>` et rendu transparent (z-index 90 sous le dock à 100) pour fermer le menu au clic extérieur sans masquer la pill avec un blur.

### Nettoyage `AccountHeader`

Les boutons Recherche et Stats du header ont été retirés — ils sont accessibles depuis le dock. Le header se contente d'afficher le nom du compte / page actif.

## Fichiers modifiés

- `mockups/option-3-bottom-tabs-fab.html`, `mockups/option-3-desktop-ipad.html` — renommages dans les mockups
- `front/src/router.ts` — nouvelle route `/gestion`
- `front/src/App.vue` — wrapper `.bottom-dock`
- `front/src/components/NavBar.vue` — refonte 4 tabs + burger
- `front/src/components/FabMenu.vue` — nouveau composant
- `front/src/views/Gestion.vue` — nouvelle vue hub
- `front/src/components/AccountHeader.vue` — suppression des deux boutons
- `front/src/components/OperationForm.vue`, `front/src/components/OperationList.vue`, `front/src/views/Amortissement.vue` — renommage du libellé visible « Amortissement » → « Coûts d'usage »
- `front/src/styles/theme.css`, `front/src/styles/variables.scss` — variables associées

## Test plan

- [ ] `pnpm --filter @mccbng/front type-check` et `pnpm --filter @mccbng/front build` passent
- [ ] Sur desktop, dock centré au bas, `CompteList` toujours visible à gauche
- [ ] Sur iPhone, dock à 15 px du bas, burger visible dans la pill, swipe + tap burger ouvrent / referment le panneau
- [ ] Onglet Gestion actif → header affiche « Gestion », hub liste les 4 cartes dans l'ordre Récurrentes / Coûts d'usage / Crédits / Biens avec leurs montants
- [ ] FAB désactivé sur Stats / Réglages / Recherche, expansion + → × correcte sur Comptes et Gestion
- [ ] Création / édition d'opération, transfert, récurrente, crédit, bien fonctionnent depuis le speed-dial
- [ ] Mode sombre OK pour le dock