### PR TITLE
feat: replace Categorie.Stats flag with a Type ENUM (depense/revenu/transfert)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ pnpm lint:check         # ESLint check only (no auto-fix)
 | **Compte** | `IDcompte` | Bank account. Type flags: `bloque`, `joint`, `children`, `retraite`, `porte_feuille`, `visible`. belongsTo `Banque`. |
 | **Operation** | `IDop` | Single transaction. Belongs to a `Compte`, optionally tied to a `Categorie` and a `Credit`. `CheckOp` = pointed/checked status, `amortissement` flag. |
 | **OperationRecurrente** | `IDopRecu` | Recurring template. `Frequence`: 3 = monthly, 7 = yearly. `DernierDateOpRecu` tracks last generation. |
-| **Categorie** | `IDcat` | User-defined classification. `Stats` flag toggles inclusion in monthly stats. |
+| **Categorie** | `IDcat` | User-defined classification. `Type` ENUM (`depense` / `revenu` / `transfert`) drives how the category is counted in each graph. |
 | **Credit** | `IDcredit` | Loan / mortgage. Auto-creates a monthly `OperationRecurrente` when created. |
 | **Bien** | `IDbien` | Real-estate asset. Optionally linked to a `Credit` (mortgage). |
 | **Stats** | `userID` | Support entity used by the analytics endpoints. |

--- a/back/CLAUDE.md
+++ b/back/CLAUDE.md
@@ -59,7 +59,7 @@ Controllers  →  Repositories  →  DataSource (MySQL)
 | **Compte** | `IDcompte` (auto-inc) | `NomCompte`, `solde` (FLOAT), `IDuser`, `IDbanque`, `bloque`, `joint`, `children`, `retraite`, `porte_feuille`, `visible` | belongsTo Banque |
 | **Operation** | `IDop` (auto-inc) | `NomOp`, `MontantOp` (FLOAT), `DateOp`, `CheckOp` (def `false`), `IDcompte`, `IDcat` (def `0`), `amortissement` (def `false`), `IDcredit?` | scoped via Compte |
 | **OperationRecurrente** | `IDopRecu` (auto-inc) | `NomOpRecu`, `MontantOpRecu` (FLOAT), `JourOpRecu`, `JourNumOpRecu` (def `1`), `MoisOpRecu` (def `1`), `Frequence` (def `3`: 3=monthly, 7=yearly), `DernierDateOpRecu`, `IDcompte`, `IDcat` (def `0`), `IDcredit?` | scoped via Compte |
-| **Categorie** | `IDcat` (auto-inc) | `Nom`, `IDuser`, `Stats` (bool, def `true`) | — |
+| **Categorie** | `IDcat` (auto-inc) | `Nom`, `IDuser`, `Type` (ENUM `depense`/`revenu`/`transfert`, def `depense`) | — |
 | **Credit** | `IDcredit` (auto-inc) | `NomCredit`, `NomPreteur?`, `MontantInitial` (FLOAT), `MontantMensuel` (FLOAT), `TauxInteret?` (FLOAT), `DateDebut`, `DateFin`, `IDcompte`, `IDopRecu?`, `IDuser`, `Statut` (def `'actif'`), `IDcat` (def `0`) | — |
 | **Bien** | `IDbien` (auto-inc) | `NomBien`, `Ville`, `TypeBien`, `Surface?` (FLOAT), `Usage` (def `'principale'`), `DateAchat`, `PrixBienNu` (FLOAT), `FraisNotaire` (FLOAT), `FraisAgence?` (FLOAT, def `0`), `ApportCash?` (FLOAT, def `0`), `ValeurActuelle?` (FLOAT), `IDcredit?`, `IDuser` | — |
 | **Stats** | `userID` | — | view-like model used by analytics |
@@ -89,11 +89,25 @@ All controllers except the public `POST /users/login`, `POST /signup`, and `GET 
 
 **Notable `OperationController` analytics endpoints:**
 
-- `GET /operations/sumAllCompteForUser` — checked / unchecked totals grouped by account.
-- `GET /operations/sumForACompte?id=<IDcompte>` — checked / unchecked totals for a single account.
-- `GET /operations/sumByUserByMonth?monthNumber=&yearNumber=&IDCompte=` — monthly total restricted to categories with `Stats=1`.
-- `GET /operations/sumCategoriesByUserByMonth?monthNumber=&yearNumber=` — per-category totals for a month.
-- `GET /operations/suggestCategories?operationName=&limit=` — category suggestions ranked by frequency of past operations whose name matches (LIKE), defaults to 5, clamped 1-50, name min length 2.
+- `GET /operations/sumAllCompteForUser` — checked / unchecked totals grouped by account (no category filter — reflects real account balances).
+- `GET /operations/sumForACompte?id=<IDcompte>` — checked / unchecked totals for a single account (no category filter).
+- `GET /operations/sumByUserByMonth?monthNumber=&yearNumber=&IDCompte=` — monthly total restricted to `Type='depense'` categories.
+- `GET /operations/sumCategoriesByUserByMonth?monthNumber=&yearNumber=` — per-category totals for a month, restricted to `Type='depense'`.
+- `GET /operations/suggestCategories?operationName=&limit=` — category suggestions ranked by frequency of past operations whose name matches (LIKE), defaults to 5, clamped 1-50, name min length 2. No Type filter (data-entry helper).
+
+### Categorie.Type and statistics
+
+`Categorie.Type` declares whether a category is a real expense, a revenue, or an internal transfer. Each statistics endpoint picks the relevant types:
+
+| Concern | Endpoints | Filter |
+|---------|-----------|--------|
+| Real account balances | `evolutionSolde`, `sumAllCompteForUser`, `sumForACompte` | none (all types — must match the bank) |
+| Pure expense analytics | `sumByUserByMonth`, `sumCategoriesByUserByMonth`, `topCategories`, `categoryHeatmap`, `yearComparison` | `Type='depense'` |
+| Income vs expense | `incomeVsExpense` (groups by Type, not by sign of `MontantOp`) | `Type IN ('depense','revenu')` |
+| Largest operations | `topOperations` | `Type IN ('depense','revenu')` (excludes transfers) |
+| Data-entry suggestions | `suggestCategories` | none |
+
+Grouping `incomeVsExpense` by `Type` rather than by the sign of `MontantOp` ensures that a refund (e.g. Sécu reimbursement) tagged on a `depense` category nets the expense correctly instead of inflating income.
 
 ### Repositories (`src/repositories/`)
 

--- a/back/migrations/2026-05-07-categorie-type.sql
+++ b/back/migrations/2026-05-07-categorie-type.sql
@@ -1,0 +1,26 @@
+-- Migration: replace Categorie.Stats boolean with a Type ENUM
+-- Date: 2026-05-07
+--
+-- The previous Stats flag conflated two distinct concepts:
+--   1) "this is a transfer / not a real income or expense" (Virement, Remboursement…)
+--   2) "this is a revenue, exclude it from the dépense-centric monthly total" (Salaire)
+-- The new Type field separates them explicitly so each graph can choose what to show.
+
+ALTER TABLE `Categorie`
+  ADD COLUMN `Type` ENUM('depense','revenu','transfert') NOT NULL DEFAULT 'depense'
+  AFTER `IDuser`;
+
+-- Backfill: every category previously excluded from stats becomes a transfer.
+UPDATE `Categorie` SET `Type` = 'transfert' WHERE `Stats` = 0;
+
+-- Salaire is the only system-shared revenue category and was historically
+-- excluded from stats only to avoid polluting the dépense-centric monthly sum.
+UPDATE `Categorie` SET `Type` = 'revenu' WHERE `IDcat` = 1;
+
+ALTER TABLE `Categorie` DROP COLUMN `Stats`;
+
+-- Rollback:
+-- ALTER TABLE `Categorie` ADD COLUMN `Stats` TINYINT(1) NOT NULL DEFAULT 1 AFTER `IDuser`;
+-- UPDATE `Categorie` SET `Stats` = 0 WHERE `Type` = 'transfert';
+-- UPDATE `Categorie` SET `Stats` = 0 WHERE `IDcat` = 1;
+-- ALTER TABLE `Categorie` DROP COLUMN `Type`;

--- a/back/src/controllers/operation.controller.ts
+++ b/back/src/controllers/operation.controller.ts
@@ -384,7 +384,7 @@ export class OperationController {
       'AND YEAR(DateOp) = ? ' +
       'AND Compte.IDuser = ? ' +
       'AND IDcat IN ' +
-      '(SELECT IDcat FROM Categorie WHERE Stats = 1 AND IDuser IN (0, ?))';
+      "(SELECT IDcat FROM Categorie WHERE Type = 'depense' AND IDuser IN (0, ?))";
 
     if (idCompte) {
       SQLrequest += ' AND IDCompte = ?';
@@ -421,7 +421,7 @@ export class OperationController {
       'AND YEAR(DateOp) = ? ' +
       'AND Compte.IDuser = ? ' +
       'AND IDcat IN ' +
-      '(SELECT IDcat FROM Categorie WHERE Stats = 1 AND IDuser IN (0, ?)) ' +
+      "(SELECT IDcat FROM Categorie WHERE Type = 'depense' AND IDuser IN (0, ?)) " +
       'GROUP BY IDcat';
 
     return this.operationRepository.execute(SQLrequest, [

--- a/back/src/controllers/stats.controller.ts
+++ b/back/src/controllers/stats.controller.ts
@@ -148,11 +148,18 @@ export class StatsController {
     @param.query.number('limit') limit?: number,
   ): Promise<AnyObject> {
     assertValidRange(from, to);
+    const userID = getCurrentUserId(currentUserProfile);
     const ids = await getUserCompteIds(
       this.compteRepository,
       currentUserProfile,
     );
-    return this.statsRepository.topOperations(ids, from, to, clampLimit(limit));
+    return this.statsRepository.topOperations(
+      userID,
+      ids,
+      from,
+      to,
+      clampLimit(limit),
+    );
   }
 
   @get('/stats/categoryHeatmap', {

--- a/back/src/models/categorie.model.ts
+++ b/back/src/models/categorie.model.ts
@@ -30,10 +30,14 @@ export class Categorie extends Entity {
   IDuser: number;
 
   @property({
-    type: 'boolean',
-    default: true,
+    type: 'string',
+    required: true,
+    default: 'depense',
+    jsonSchema: {
+      enum: ['depense', 'revenu', 'transfert'],
+    },
   })
-  Stats?: boolean;
+  Type: 'depense' | 'revenu' | 'transfert';
 
   // Define well-known properties here
 

--- a/back/src/repositories/stats.repository.ts
+++ b/back/src/repositories/stats.repository.ts
@@ -75,9 +75,10 @@ export class StatsRepository extends DefaultCrudRepository<
     };
   }
 
-  // Sum of MontantOp grouped by month for two years, restricted to the user's
-  // accounts and to categories flagged for stats. Returns 12-slot arrays
-  // (Jan -> Dec) plus the percentage delta of yearB vs yearA per month.
+  // Net dépense by month for two years (categories of Type='depense' only,
+  // including any positive operations in those categories such as a Sécu
+  // refund tagged on the medical category — they correctly net the expense).
+  // Returns 12-slot arrays (Jan -> Dec) plus the percentage delta yearB vs yearA.
   async yearComparison(
     userID: number,
     compteIds: number[],
@@ -99,7 +100,7 @@ export class StatsRepository extends DefaultCrudRepository<
       `WHERE IDcompte IN (${placeholders}) ` +
       'AND YEAR(DateOp) IN (?, ?) ' +
       'AND IDcat IN ' +
-      '(SELECT IDcat FROM Categorie WHERE Stats = 1 AND IDuser IN (0, ?)) ' +
+      "(SELECT IDcat FROM Categorie WHERE Type = 'depense' AND IDuser IN (0, ?)) " +
       'GROUP BY YEAR(DateOp), MONTH(DateOp)';
 
     const params = [...compteIds, yearA, yearB, userID];
@@ -126,7 +127,7 @@ export class StatsRepository extends DefaultCrudRepository<
   }
 
   // Top spending categories on a date range. Expenses are negative so we sort
-  // ASC (largest expense first). Filters out non-stats categories.
+  // ASC (largest expense first). Restricted to Type='depense' categories.
   async topCategories(
     userID: number,
     compteIds: number[],
@@ -143,7 +144,7 @@ export class StatsRepository extends DefaultCrudRepository<
       'INNER JOIN Categorie c ON c.IDcat = o.IDcat ' +
       `WHERE o.IDcompte IN (${placeholders}) ` +
       'AND o.DateOp >= ? AND o.DateOp <= ? ' +
-      'AND c.Stats = 1 AND c.IDuser IN (0, ?) ' +
+      "AND c.Type = 'depense' AND c.IDuser IN (0, ?) " +
       'GROUP BY o.IDcat, c.Nom ' +
       'ORDER BY total ASC ' +
       'LIMIT ?';
@@ -151,7 +152,9 @@ export class StatsRepository extends DefaultCrudRepository<
     return this.execute(sql, [...compteIds, from, to, userID, limit]);
   }
 
-  // Splits monthly totals into income (MontantOp > 0) and expense (< 0).
+  // Splits monthly totals by category Type rather than by operation sign so
+  // that a refund (e.g. Sécu reimbursement) tagged on a Type='depense'
+  // category correctly nets the expense instead of inflating income.
   async incomeVsExpense(
     userID: number,
     compteIds: number[],
@@ -165,15 +168,15 @@ export class StatsRepository extends DefaultCrudRepository<
     }
     const placeholders = new Array(compteIds.length).fill('?').join(',');
     const sql =
-      'SELECT MONTH(DateOp) AS m, ' +
-      'ROUND(SUM(CASE WHEN MontantOp > 0 THEN MontantOp ELSE 0 END), 2) AS income, ' +
-      'ROUND(SUM(CASE WHEN MontantOp < 0 THEN MontantOp ELSE 0 END), 2) AS expense ' +
-      'FROM Operation ' +
-      `WHERE IDcompte IN (${placeholders}) ` +
-      'AND YEAR(DateOp) = ? ' +
-      'AND IDcat IN ' +
-      '(SELECT IDcat FROM Categorie WHERE Stats = 1 AND IDuser IN (0, ?)) ' +
-      'GROUP BY MONTH(DateOp)';
+      'SELECT MONTH(o.DateOp) AS m, ' +
+      "ROUND(SUM(CASE WHEN c.Type = 'revenu' THEN o.MontantOp ELSE 0 END), 2) AS income, " +
+      "ROUND(SUM(CASE WHEN c.Type = 'depense' THEN o.MontantOp ELSE 0 END), 2) AS expense " +
+      'FROM Operation o ' +
+      'INNER JOIN Categorie c ON c.IDcat = o.IDcat ' +
+      `WHERE o.IDcompte IN (${placeholders}) ` +
+      'AND YEAR(o.DateOp) = ? ' +
+      "AND c.Type IN ('depense','revenu') AND c.IDuser IN (0, ?) " +
+      'GROUP BY MONTH(o.DateOp)';
 
     const rows = (await this.execute(sql, [
       ...compteIds,
@@ -195,8 +198,10 @@ export class StatsRepository extends DefaultCrudRepository<
     return {income, expense};
   }
 
-  // Largest operations (in absolute value) over a date range.
+  // Largest operations (in absolute value) over a date range. Excludes
+  // transfers so internal moves don't dominate the ranking.
   async topOperations(
+    userID: number,
     compteIds: number[],
     from: string,
     to: string,
@@ -205,14 +210,16 @@ export class StatsRepository extends DefaultCrudRepository<
     if (compteIds.length === 0) return [];
     const placeholders = new Array(compteIds.length).fill('?').join(',');
     const sql =
-      'SELECT IDop, NomOp, MontantOp, DateOp, IDcat, IDcompte ' +
-      'FROM Operation ' +
-      `WHERE IDcompte IN (${placeholders}) ` +
-      'AND DateOp >= ? AND DateOp <= ? ' +
-      'ORDER BY ABS(MontantOp) DESC ' +
+      'SELECT o.IDop, o.NomOp, o.MontantOp, o.DateOp, o.IDcat, o.IDcompte ' +
+      'FROM Operation o ' +
+      'INNER JOIN Categorie c ON c.IDcat = o.IDcat ' +
+      `WHERE o.IDcompte IN (${placeholders}) ` +
+      'AND o.DateOp >= ? AND o.DateOp <= ? ' +
+      "AND c.Type IN ('depense','revenu') AND c.IDuser IN (0, ?) " +
+      'ORDER BY ABS(o.MontantOp) DESC ' +
       'LIMIT ?';
 
-    return this.execute(sql, [...compteIds, from, to, limit]);
+    return this.execute(sql, [...compteIds, from, to, userID, limit]);
   }
 
   // Heatmap matrix: month (0-11) x category. Returns the per-cell total
@@ -234,7 +241,7 @@ export class StatsRepository extends DefaultCrudRepository<
       'INNER JOIN Categorie c ON c.IDcat = o.IDcat ' +
       `WHERE o.IDcompte IN (${placeholders}) ` +
       'AND YEAR(o.DateOp) = ? ' +
-      'AND c.Stats = 1 AND c.IDuser IN (0, ?) ' +
+      "AND c.Type = 'depense' AND c.IDuser IN (0, ?) " +
       'GROUP BY MONTH(o.DateOp), o.IDcat, c.Nom';
 
     const rows = (await this.execute(sql, [


### PR DESCRIPTION
The single Stats boolean conflated two unrelated concerns: "this is a
transfer" (Virement, Remboursement…) and "this is a revenue, exclude it
from the dépense-centric monthly total" (Salaire). With the new
income-vs-expense and heatmap graphs the conflation became visible:
Salaire was hidden from incomeVsExpense, and a Sécu refund tagged on a
medical category would inflate income instead of netting the expense.

The new Type ENUM lets each graph pick the relevant categories:
- balance/account totals: all types (must match the bank)
- expense analytics (sumByUserByMonth, topCategories, heatmap, …): Type='depense'
- income vs expense: groups by Type rather than by sign of MontantOp,
  so refunds tagged on a depense category correctly net the expense
- topOperations: now excludes transfers (was missing the filter entirely)
- suggestCategories: unchanged (data-entry helper, no Type filter)

Migration backfills Stats=0 → 'transfert' and Salaire (IDcat=1) → 'revenu',
then drops the Stats column.

https://claude.ai/code/session_01VeDyhyCbVZB8ar8SSKVMNP