### PR TITLE
refactor(front): replace axios with native fetch wrapper

### DIFF
--- a/front/CLAUDE.md
+++ b/front/CLAUDE.md
@@ -122,7 +122,7 @@ Eight modules, no namespacing — accessed as `store.state.<module>.<prop>` and 
 
 ### Services (`src/services/`)
 
-API layer using Axios. Each function accepts `token` and `apiUrl` so services stay stateless.
+API layer built on the native `fetch` API via the small wrapper in `services/http.ts` (`apiGet`, `apiPost`, `apiPut`, `apiPatch`, `apiDelete`). Each function accepts `token` and `apiUrl` so services stay stateless.
 
 | Service | Functions | API Endpoints |
 |---------|-----------|---------------|
@@ -248,7 +248,7 @@ Configured via `vite-plugin-pwa` in `vite.config.ts`:
 ### Vite Configuration (`vite.config.ts`)
 
 - **Dev server**: port 8080, proxies `/api` to `VITE_API_URL` (default `http://localhost:3000`).
-- **Build**: manual chunks — `vue` (vue / vue-router / vuex), `vendor` (axios / highcharts).
+- **Build**: manual chunks — `vue` (vue / vue-router / vuex), `vendor` (highcharts).
 - **SCSS**: modern compiler API, global variables injection.
 - **Aliases**: `@` → `src/`.
 - **Vue flags**: Options API enabled, prod devtools disabled.
@@ -267,7 +267,6 @@ Configured via `vite-plugin-pwa` in `vite.config.ts`:
 
 ### Runtime
 - `vue` ^3.5, `vue-router` ^4.5, `vuex` ^4.1 — core framework
-- `axios` ^1.13 — HTTP client
 - `highcharts` ^12.2 — charts
 - `@fortawesome/fontawesome-svg-core`, `@fortawesome/free-solid-svg-icons`, `@fortawesome/vue-fontawesome` — icons
 - `universal-cookie` ^4 — cookie management for auth
@@ -312,7 +311,7 @@ front/
 │   │   ├── display.ts                # UI panel toggle
 │   │   ├── credit.ts                 # loans + remaining balances
 │   │   └── bien.ts                   # real-estate assets
-│   ├── services/                     # axios services per domain (auth, user, compte, operation, category, stats, credit, bien)
+│   ├── services/                     # fetch-based services per domain (auth, user, compte, operation, category, stats, credit, bien) + http.ts wrapper
 │   ├── composables/
 │   │   ├── useTheme.ts               # theme system (light/dark/system)
 │   │   └── useDebugTools.ts          # Eruda lazy load
@@ -354,8 +353,8 @@ front/
 ## Conventions When Editing
 
 - Use `<script setup lang="ts">` and the Composition API in new components.
-- Add a new domain by creating: a `services/<domain>.ts` (axios), a `store/<domain>.ts` (module registered in `store/index.ts`), and components under `components/`.
+- Add a new domain by creating: a `services/<domain>.ts` (using `services/http.ts`), a `store/<domain>.ts` (module registered in `store/index.ts`), and components under `components/`.
 - Modal-style flows should be modeled as **child routes** with `RouteOverTheContent` and a `componentName` prop, not as imperative components.
 - For currency display, prefer `<Currency :amount="…" />` so the locale and symbol stay centralised.
 - Read auth from `getTokenCookie()` / `getUserIDCookie()` rather than from the Vuex store when calling services from outside Vue components.
-- Keep state mutations free of axios calls — services do the I/O, actions orchestrate.
+- Keep state mutations free of HTTP calls — services do the I/O, actions orchestrate.

--- a/front/package.json
+++ b/front/package.json
@@ -27,7 +27,6 @@
     "@fortawesome/fontawesome-svg-core": "^6.7.0",
     "@fortawesome/free-solid-svg-icons": "^6.7.0",
     "@fortawesome/vue-fontawesome": "^3.1.3",
-    "axios": "^1.13.0",
     "core-js": "^3.41.0",
     "eruda": "^3.4.3",
     "highcharts": "^12.2.0",

--- a/front/src/services/auth.ts
+++ b/front/src/services/auth.ts
@@ -1,5 +1,6 @@
-import axios from 'axios'
 import Cookies from 'universal-cookie'
+
+import { apiGet, apiPost } from './http'
 
 const COOKIE_TOKEN = 'userToken'
 const COOKIE_USER_ID = 'userID'
@@ -50,25 +51,17 @@ export const clearLastEmail = () => {
   }
 }
 
-export const auth = (email: string, code: string, apiUrl: string) => {
-  return axios
-    .post(apiUrl + '/api/users/login', {
-      email,
-      code
-    })
-    .then((response) => {
-      if (response.status === 200) {
-        return {
-          userToken: response.data.id,
-          ttl: response.data.ttl,
-          userID: response.data.userId
-        }
-      }
-      throw new Error('Authentication failed')
-    })
-    .catch((error) => {
-      throw new Error(error)
-    })
+export const auth = async (email: string, code: string, apiUrl: string) => {
+  const data = await apiPost<{ id: string; ttl: number; userId: number }>(
+    apiUrl + '/api/users/login',
+    { email, code }
+  )
+
+  return {
+    userToken: data.id,
+    ttl: data.ttl,
+    userID: data.userId
+  }
 }
 
 export const saveCookies = ({ userToken, userID }) => {
@@ -86,21 +79,16 @@ export const removeCookies = () => {
   cookie.remove(COOKIE_USER_ID, opts)
 }
 
-export const checkUserAuthentification = ({ userToken, apiUrl }) => {
-  return axios
-    .get(apiUrl + '/api/users/exists', {
-      headers: {
-        Authorization: 'Bearer ' + userToken
-      }
-    })
-    .then(() => {
-      return true
-    })
-    .catch(() => {
-      removeCookies()
+export const checkUserAuthentification = async ({ userToken, apiUrl }) => {
+  try {
+    await apiGet(apiUrl + '/api/users/exists', { token: userToken })
 
-      return false
-    })
+    return true
+  } catch {
+    removeCookies()
+
+    return false
+  }
 }
 
 export default {

--- a/front/src/services/banque.ts
+++ b/front/src/services/banque.ts
@@ -1,29 +1,16 @@
-import axios from 'axios'
+import { apiGet, apiPost } from './http'
 
 export const fetchBanques = (userToken, APIURL) => {
   const filter = { order: 'NomBanque ASC' }
 
-  return axios.get(APIURL + '/api/banques', {
-    headers: {
-      Authorization: 'Bearer ' + userToken
-    },
-    params: {
-      filter
-    }
-  }).then((response) => {
-    return response.data
+  return apiGet(APIURL + '/api/banques', {
+    token: userToken,
+    params: { filter }
   })
 }
 
-export const createBanque = (banque, userToken, APIURL) => {
-  return axios.post(APIURL + '/api/banques', banque, {
-    headers: {
-      Authorization: 'Bearer ' + userToken
-    }
-  }).then((response) => {
-    return response.data
-  })
-}
+export const createBanque = (banque, userToken, APIURL) =>
+  apiPost(APIURL + '/api/banques', banque, { token: userToken })
 
 export default {
   fetchBanques,

--- a/front/src/services/bien.ts
+++ b/front/src/services/bien.ts
@@ -1,57 +1,22 @@
-import axios from 'axios'
+import { apiDelete, apiGet, apiPost, apiPut } from './http'
 
-export const fetchBiens = (userToken, APIURL) => {
-  return axios
-    .get(APIURL + '/api/biens', {
-      headers: {
-        Authorization: 'Bearer ' + userToken
-      }
-    })
-    .then((response) => {
-      return response.data
-    })
-}
+export const fetchBiens = (userToken, APIURL) =>
+  apiGet(APIURL + '/api/biens', { token: userToken })
 
-export const fetchBienById = (IDbien, userToken, APIURL) => {
-  return axios
-    .get(APIURL + '/api/biens/' + IDbien, {
-      headers: {
-        Authorization: 'Bearer ' + userToken
-      }
-    })
-    .then((response) => {
-      return response.data
-    })
-}
+export const fetchBienById = (IDbien, userToken, APIURL) =>
+  apiGet(APIURL + '/api/biens/' + IDbien, { token: userToken })
 
 export const updateBien = (bien, userToken, APIURL) => {
   if (bien.IDbien) {
-    return axios.put(
+    return apiPut(
       APIURL + '/api/biens/' + bien.IDbien,
       { ...bien, IDbien: undefined },
-      {
-        headers: {
-          Authorization: 'Bearer ' + userToken
-        }
-      }
-    )
-  } else {
-    return axios.post(
-      APIURL + '/api/biens/',
-      bien,
-      {
-        headers: {
-          Authorization: 'Bearer ' + userToken
-        }
-      }
+      { token: userToken }
     )
   }
+
+  return apiPost(APIURL + '/api/biens/', bien, { token: userToken })
 }
 
-export const deleteBien = (IDbien, userToken, APIURL) => {
-  return axios.delete(APIURL + '/api/biens/' + IDbien, {
-    headers: {
-      Authorization: 'Bearer ' + userToken
-    }
-  })
-}
+export const deleteBien = (IDbien, userToken, APIURL) =>
+  apiDelete(APIURL + '/api/biens/' + IDbien, { token: userToken })

--- a/front/src/services/category.ts
+++ b/front/src/services/category.ts
@@ -1,17 +1,14 @@
-import axios from 'axios'
+import { apiGet } from './http'
 
 export const fetchCategoryList = (IDuser, userToken, APIURL) => {
-  const filter = { where: { or: [{ IDuser }, { IDuser: 0 }] }, order: 'Nom ASC' }
+  const filter = {
+    where: { or: [{ IDuser }, { IDuser: 0 }] },
+    order: 'Nom ASC'
+  }
 
-  return axios.get(APIURL + '/api/categories', {
-    headers: {
-      Authorization: 'Bearer ' + userToken
-    },
-    params: {
-      filter
-    }
-  }).then((response) => {
-    return response.data
+  return apiGet(APIURL + '/api/categories', {
+    token: userToken,
+    params: { filter }
   })
 }
 

--- a/front/src/services/compte.ts
+++ b/front/src/services/compte.ts
@@ -1,88 +1,44 @@
-import axios from 'axios'
+import { apiDelete, apiGet, apiPatch, apiPost } from './http'
 
-export const fetchAccountList = (userID, userToken, APIURL) => {
-  const filter = { include: [{ relation: 'banque' }], where: { IDuser: userID }, order: 'NomCompte ASC' }
+export const fetchAccountList = async (userID, userToken, APIURL) => {
+  const filter = {
+    include: [{ relation: 'banque' }],
+    where: { IDuser: userID },
+    order: 'NomCompte ASC'
+  }
 
-  return axios.get(APIURL + '/api/comptes', {
-    headers: {
-      Authorization: 'Bearer ' + userToken
-    },
-    params: {
-      filter
-    }
-  }).then((response) => {
-    return response.data.map((account) => {
-      return {
-        ...account,
-        soldeNotChecked: 0,
-        soldeChecked: 0
-      }
-    })
+  const data = await apiGet<any[]>(APIURL + '/api/comptes', {
+    token: userToken,
+    params: { filter }
   })
+
+  return data.map((account) => ({
+    ...account,
+    soldeNotChecked: 0,
+    soldeChecked: 0
+  }))
 }
 
-export const sumAllCompteForUser = (userToken, APIURL) => {
-  return axios.get(APIURL + '/api/operations/sumAllCompteForUser', {
-    headers: {
-      Authorization: 'Bearer ' + userToken
-    }
-  }).then((response) => {
-    return response.data
-  })
-}
+export const sumAllCompteForUser = (userToken, APIURL) =>
+  apiGet(APIURL + '/api/operations/sumAllCompteForUser', { token: userToken })
 
-export const sumForACompte = (userToken, IDcompte, APIURL) => {
-  return axios.get(APIURL + '/api/operations/sumForACompte', {
-    headers: {
-      Authorization: 'Bearer ' + userToken
-    },
-    params: {
-      id: IDcompte
-    }
-  }).then((response) => {
-    return response.data
+export const sumForACompte = (userToken, IDcompte, APIURL) =>
+  apiGet(APIURL + '/api/operations/sumForACompte', {
+    token: userToken,
+    params: { id: IDcompte }
   })
-}
 
-export const createCompte = (compte, userToken, APIURL) => {
-  return axios.post(APIURL + '/api/comptes', compte, {
-    headers: {
-      Authorization: 'Bearer ' + userToken
-    }
-  }).then((response) => {
-    return response.data
-  })
-}
+export const createCompte = (compte, userToken, APIURL) =>
+  apiPost(APIURL + '/api/comptes', compte, { token: userToken })
 
-export const updateCompte = (IDcompte, compte, userToken, APIURL) => {
-  return axios.patch(APIURL + '/api/comptes/' + IDcompte, compte, {
-    headers: {
-      Authorization: 'Bearer ' + userToken
-    }
-  }).then((response) => {
-    return response.data
-  })
-}
+export const updateCompte = (IDcompte, compte, userToken, APIURL) =>
+  apiPatch(APIURL + '/api/comptes/' + IDcompte, compte, { token: userToken })
 
-export const deleteCompte = (IDcompte, userToken, APIURL) => {
-  return axios.delete(APIURL + '/api/comptes/' + IDcompte, {
-    headers: {
-      Authorization: 'Bearer ' + userToken
-    }
-  }).then((response) => {
-    return response.data
-  })
-}
+export const deleteCompte = (IDcompte, userToken, APIURL) =>
+  apiDelete(APIURL + '/api/comptes/' + IDcompte, { token: userToken })
 
-export const fetchComptesManagementInfo = (userToken, APIURL) => {
-  return axios.get(APIURL + '/api/comptes/management-info', {
-    headers: {
-      Authorization: 'Bearer ' + userToken
-    }
-  }).then((response) => {
-    return response.data
-  })
-}
+export const fetchComptesManagementInfo = (userToken, APIURL) =>
+  apiGet(APIURL + '/api/comptes/management-info', { token: userToken })
 
 export default {
   fetchAccountList,

--- a/front/src/services/credit.ts
+++ b/front/src/services/credit.ts
@@ -1,81 +1,32 @@
-import axios from 'axios'
+import { apiDelete, apiGet, apiPost, apiPut } from './http'
 
-export const fetchCredits = (userToken, APIURL) => {
-  return axios
-    .get(APIURL + '/api/credits', {
-      headers: {
-        Authorization: 'Bearer ' + userToken
-      }
-    })
-    .then((response) => {
-      return response.data
-    })
-}
+export const fetchCredits = (userToken, APIURL) =>
+  apiGet(APIURL + '/api/credits', { token: userToken })
 
-export const fetchCreditById = (IDcredit, userToken, APIURL) => {
-  return axios
-    .get(APIURL + '/api/credits/' + IDcredit, {
-      headers: {
-        Authorization: 'Bearer ' + userToken
-      }
-    })
-    .then((response) => {
-      return response.data
-    })
-}
+export const fetchCreditById = (IDcredit, userToken, APIURL) =>
+  apiGet(APIURL + '/api/credits/' + IDcredit, { token: userToken })
 
 export const updateCredit = (credit, userToken, APIURL) => {
   if (credit.IDcredit) {
-    return axios.put(
+    return apiPut(
       APIURL + '/api/credits/' + credit.IDcredit,
       { ...credit, IDcredit: undefined },
-      {
-        headers: {
-          Authorization: 'Bearer ' + userToken
-        }
-      }
-    )
-  } else {
-    return axios.post(
-      APIURL + '/api/credits/',
-      credit,
-      {
-        headers: {
-          Authorization: 'Bearer ' + userToken
-        }
-      }
+      { token: userToken }
     )
   }
+
+  return apiPost(APIURL + '/api/credits/', credit, { token: userToken })
 }
 
-export const deleteCredit = (IDcredit, userToken, APIURL) => {
-  return axios.delete(APIURL + '/api/credits/' + IDcredit, {
-    headers: {
-      Authorization: 'Bearer ' + userToken
-    }
+export const deleteCredit = (IDcredit, userToken, APIURL) =>
+  apiDelete(APIURL + '/api/credits/' + IDcredit, { token: userToken })
+
+export const fetchCreditRemainingBalance = (IDcredit, userToken, APIURL) =>
+  apiGet(APIURL + '/api/credits/' + IDcredit + '/remaining-balance', {
+    token: userToken
   })
-}
 
-export const fetchCreditRemainingBalance = (IDcredit, userToken, APIURL) => {
-  return axios
-    .get(APIURL + '/api/credits/' + IDcredit + '/remaining-balance', {
-      headers: {
-        Authorization: 'Bearer ' + userToken
-      }
-    })
-    .then((response) => {
-      return response.data
-    })
-}
-
-export const fetchCreditPayments = (IDcredit, userToken, APIURL) => {
-  return axios
-    .get(APIURL + '/api/credits/' + IDcredit + '/payments', {
-      headers: {
-        Authorization: 'Bearer ' + userToken
-      }
-    })
-    .then((response) => {
-      return response.data
-    })
-}
+export const fetchCreditPayments = (IDcredit, userToken, APIURL) =>
+  apiGet(APIURL + '/api/credits/' + IDcredit + '/payments', {
+    token: userToken
+  })

--- a/front/src/services/http.ts
+++ b/front/src/services/http.ts
@@ -1,0 +1,80 @@
+type Params = Record<string, unknown>
+
+export interface ApiOptions {
+  token?: string
+  params?: Params
+}
+
+const buildQueryString = (params?: Params): string => {
+  if (!params) return ''
+  const search = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) continue
+    search.append(
+      key,
+      typeof value === 'object' ? JSON.stringify(value) : String(value)
+    )
+  }
+  const qs = search.toString()
+  return qs ? `?${qs}` : ''
+}
+
+const request = async <T>(
+  method: string,
+  url: string,
+  opts: ApiOptions & { body?: unknown } = {}
+): Promise<T> => {
+  const headers: Record<string, string> = {}
+  if (opts.token) headers.Authorization = `Bearer ${opts.token}`
+
+  let body: BodyInit | undefined
+  if (opts.body !== undefined) {
+    headers['Content-Type'] = 'application/json'
+    body = JSON.stringify(opts.body)
+  }
+
+  const response = await fetch(url + buildQueryString(opts.params), {
+    method,
+    headers,
+    body
+  })
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} ${response.statusText}`)
+  }
+
+  if (response.status === 204) return undefined as T
+
+  const text = await response.text()
+  if (!text) return undefined as T
+
+  try {
+    return JSON.parse(text) as T
+  } catch {
+    return text as unknown as T
+  }
+}
+
+export const apiGet = <T = any>(url: string, opts?: ApiOptions) =>
+  request<T>('GET', url, opts)
+
+export const apiPost = <T = any>(
+  url: string,
+  body?: unknown,
+  opts?: ApiOptions
+) => request<T>('POST', url, { ...opts, body })
+
+export const apiPut = <T = any>(
+  url: string,
+  body?: unknown,
+  opts?: ApiOptions
+) => request<T>('PUT', url, { ...opts, body })
+
+export const apiPatch = <T = any>(
+  url: string,
+  body?: unknown,
+  opts?: ApiOptions
+) => request<T>('PATCH', url, { ...opts, body })
+
+export const apiDelete = <T = any>(url: string, opts?: ApiOptions) =>
+  request<T>('DELETE', url, opts)

--- a/front/src/services/operation.ts
+++ b/front/src/services/operation.ts
@@ -1,6 +1,12 @@
-import axios from 'axios'
+import { apiDelete, apiGet, apiPost, apiPut } from './http'
 
-export const fetchOperationsForAccount = (IDcompte, userToken, APIURL, skip = 0, limit = 35) => {
+export const fetchOperationsForAccount = (
+  IDcompte,
+  userToken,
+  APIURL,
+  skip = 0,
+  limit = 35
+) => {
   const filter = {
     where: { IDcompte },
     order: 'CheckOp ASC, DateOp DESC',
@@ -8,51 +14,30 @@ export const fetchOperationsForAccount = (IDcompte, userToken, APIURL, skip = 0,
     skip
   }
 
-  return axios
-    .get(APIURL + '/api/operations', {
-      headers: {
-        Authorization: 'Bearer ' + userToken
-      },
-      params: {
-        filter
-      }
-    })
-    .then((response) => {
-      return response.data
-    })
+  return apiGet(APIURL + '/api/operations', {
+    token: userToken,
+    params: { filter }
+  })
 }
 
 export const updateOperation = (operation, userToken, APIURL) => {
   if (operation.IDop) {
-    return axios.put(
+    return apiPut(
       APIURL + '/api/operations/' + operation.IDop,
       { ...operation, IDop: undefined },
-      {
-        headers: {
-          Authorization: 'Bearer ' + userToken
-        }
-      }
-    )
-  } else {
-    return axios.post(
-      APIURL + '/api/operations/',
-      { ...operation, IDcompteCredit: undefined, IDcompteDebit: undefined },
-      {
-        headers: {
-          Authorization: 'Bearer ' + userToken
-        }
-      }
+      { token: userToken }
     )
   }
+
+  return apiPost(
+    APIURL + '/api/operations/',
+    { ...operation, IDcompteCredit: undefined, IDcompteDebit: undefined },
+    { token: userToken }
+  )
 }
 
-export const deleteOperation = (IDoperation, userToken, APIURL) => {
-  return axios.delete(APIURL + '/api/operations/' + IDoperation, {
-    headers: {
-      Authorization: 'Bearer ' + userToken
-    }
-  })
-}
+export const deleteOperation = (IDoperation, userToken, APIURL) =>
+  apiDelete(APIURL + '/api/operations/' + IDoperation, { token: userToken })
 
 export const fetchSearchOperations = (
   searchTerms,
@@ -75,30 +60,16 @@ export const fetchSearchOperations = (
     skip
   }
 
-  return axios
-    .get(APIURL + '/api/operations', {
-      headers: {
-        Authorization: 'Bearer ' + userToken
-      },
-      params: {
-        filter
-      }
-    })
-    .then((response) => {
-      return response.data
-    })
+  return apiGet(APIURL + '/api/operations', {
+    token: userToken,
+    params: { filter }
+  })
 }
 
 export const generateRecurringOperations = (userToken, APIURL) => {
-  axios.post(
-    APIURL + '/api/operation-recurrentes/auto-generation',
-    {},
-    {
-      headers: {
-        Authorization: 'Bearer ' + userToken
-      }
-    }
-  )
+  apiPost(APIURL + '/api/operation-recurrentes/auto-generation', {}, {
+    token: userToken
+  })
 }
 
 export const fetchRecurrOperation = (userToken, APIURL) => {
@@ -106,51 +77,32 @@ export const fetchRecurrOperation = (userToken, APIURL) => {
     order: 'DernierDateOpRecu DESC, NomOpRecu ASC'
   }
 
-  return axios
-    .get(APIURL + '/api/operation-recurrentes', {
-      headers: {
-        Authorization: 'Bearer ' + userToken
-      },
-      params: {
-        filter
-      }
-    })
-    .then((response) => {
-      return response.data
-    })
+  return apiGet(APIURL + '/api/operation-recurrentes', {
+    token: userToken,
+    params: { filter }
+  })
 }
 
 export const updateRecurringOperation = (operationRecurrente, userToken, APIURL) => {
   if (operationRecurrente.IDopRecu) {
-    return axios.put(
+    return apiPut(
       APIURL + '/api/operation-recurrentes/' + operationRecurrente.IDopRecu,
       { ...operationRecurrente, IDopRecu: undefined },
-      {
-        headers: {
-          Authorization: 'Bearer ' + userToken
-        }
-      }
-    )
-  } else {
-    return axios.post(
-      APIURL + '/api/operation-recurrentes/',
-      operationRecurrente,
-      {
-        headers: {
-          Authorization: 'Bearer ' + userToken
-        }
-      }
+      { token: userToken }
     )
   }
+
+  return apiPost(
+    APIURL + '/api/operation-recurrentes/',
+    operationRecurrente,
+    { token: userToken }
+  )
 }
 
-export const deleteRecurringOperation = (IDopRecu, userToken, APIURL) => {
-  return axios.delete(APIURL + '/api/operation-recurrentes/' + IDopRecu, {
-    headers: {
-      Authorization: 'Bearer ' + userToken
-    }
+export const deleteRecurringOperation = (IDopRecu, userToken, APIURL) =>
+  apiDelete(APIURL + '/api/operation-recurrentes/' + IDopRecu, {
+    token: userToken
   })
-}
 
 export const fetchOperations = (where, userToken, APIURL) => {
   const filter = {
@@ -158,37 +110,26 @@ export const fetchOperations = (where, userToken, APIURL) => {
     order: 'DateOp DESC'
   }
 
-  return axios
-    .get(APIURL + '/api/operations', {
-      headers: {
-        Authorization: 'Bearer ' + userToken
-      },
-      params: {
-        filter
-      }
-    })
-    .then((response) => {
-      return response.data
-    })
+  return apiGet(APIURL + '/api/operations', {
+    token: userToken,
+    params: { filter }
+  })
 }
 
-export const suggestCategories = (operationName, userToken, APIURL, limit = 5) => {
-  return axios
-    .get(APIURL + '/api/operations/suggestCategories', {
-      headers: {
-        Authorization: 'Bearer ' + userToken
-      },
-      params: {
-        operationName,
-        limit
-      }
+export const suggestCategories = async (
+  operationName,
+  userToken,
+  APIURL,
+  limit = 5
+) => {
+  try {
+    return await apiGet(APIURL + '/api/operations/suggestCategories', {
+      token: userToken,
+      params: { operationName, limit }
     })
-    .then((response) => {
-      return response.data
-    })
-    .catch(() => {
-      return []
-    })
+  } catch {
+    return []
+  }
 }
 
 export default {

--- a/front/src/services/stats.ts
+++ b/front/src/services/stats.ts
@@ -1,49 +1,37 @@
-import axios from 'axios'
+import { apiGet } from './http'
 
-export const fetchEvolutionSolde = (userToken, APIURL) => {
-  return axios.get(APIURL + '/api/stats/evolutionSolde', {
-    headers: {
-      Authorization: 'Bearer ' + userToken
-    }
-  }).then((response) => {
-    return response.data
-  })
-}
+export const fetchEvolutionSolde = (userToken, APIURL) =>
+  apiGet(APIURL + '/api/stats/evolutionSolde', { token: userToken })
 
-export const fetchYearComparison = (yearA, yearB, userToken, APIURL) => {
-  return axios.get(APIURL + '/api/stats/yearComparison', {
-    headers: { Authorization: 'Bearer ' + userToken },
+export const fetchYearComparison = (yearA, yearB, userToken, APIURL) =>
+  apiGet(APIURL + '/api/stats/yearComparison', {
+    token: userToken,
     params: { yearA, yearB }
-  }).then((response) => response.data)
-}
+  })
 
-export const fetchTopCategories = (from, to, limit, userToken, APIURL) => {
-  return axios.get(APIURL + '/api/stats/topCategories', {
-    headers: { Authorization: 'Bearer ' + userToken },
+export const fetchTopCategories = (from, to, limit, userToken, APIURL) =>
+  apiGet(APIURL + '/api/stats/topCategories', {
+    token: userToken,
     params: { from, to, limit }
-  }).then((response) => response.data)
-}
+  })
 
-export const fetchIncomeVsExpense = (yearNumber, userToken, APIURL) => {
-  return axios.get(APIURL + '/api/stats/incomeVsExpense', {
-    headers: { Authorization: 'Bearer ' + userToken },
+export const fetchIncomeVsExpense = (yearNumber, userToken, APIURL) =>
+  apiGet(APIURL + '/api/stats/incomeVsExpense', {
+    token: userToken,
     params: { yearNumber }
-  }).then((response) => response.data)
-}
+  })
 
-export const fetchTopOperations = (from, to, limit, userToken, APIURL) => {
-  return axios.get(APIURL + '/api/stats/topOperations', {
-    headers: { Authorization: 'Bearer ' + userToken },
+export const fetchTopOperations = (from, to, limit, userToken, APIURL) =>
+  apiGet(APIURL + '/api/stats/topOperations', {
+    token: userToken,
     params: { from, to, limit }
-  }).then((response) => response.data)
-}
+  })
 
-export const fetchCategoryHeatmap = (yearNumber, userToken, APIURL) => {
-  return axios.get(APIURL + '/api/stats/categoryHeatmap', {
-    headers: { Authorization: 'Bearer ' + userToken },
+export const fetchCategoryHeatmap = (yearNumber, userToken, APIURL) =>
+  apiGet(APIURL + '/api/stats/categoryHeatmap', {
+    token: userToken,
     params: { yearNumber }
-  }).then((response) => response.data)
-}
+  })
 
 export default {
   fetchEvolutionSolde,

--- a/front/src/services/user.ts
+++ b/front/src/services/user.ts
@@ -1,33 +1,27 @@
-import axios from 'axios'
+import { apiGet, apiPatch } from './http'
 
-export const fetchUser = (_, userToken, apiUrl) => {
-  return axios.get(apiUrl + '/api/users/whoAmI', {
-    headers: {
-      Authorization: 'Bearer ' + userToken
-    }
-  }).then((response) => {
-    return {
-      id: response.data.IDuser,
-      favoris: response.data.favoris,
-      warningTotal: response.data.warningTotal,
-      warningCompte: response.data.warningCompte,
-      email: response.data.email,
-      username: response.data.username
-    }
-  }).catch((error) => {
-    throw new Error(error)
-  })
+export const fetchUser = async (_, userToken, apiUrl) => {
+  const data = await apiGet<{
+    IDuser: number
+    favoris: unknown
+    warningTotal: unknown
+    warningCompte: unknown
+    email: string
+    username: string
+  }>(apiUrl + '/api/users/whoAmI', { token: userToken })
+
+  return {
+    id: data.IDuser,
+    favoris: data.favoris,
+    warningTotal: data.warningTotal,
+    warningCompte: data.warningCompte,
+    email: data.email,
+    username: data.username
+  }
 }
 
-export const updateUser = (updates, userToken, apiUrl) => {
-  return axios.patch(apiUrl + '/api/users/me', updates, {
-    headers: {
-      Authorization: 'Bearer ' + userToken
-    }
-  }).catch((error) => {
-    throw new Error(error)
-  })
-}
+export const updateUser = (updates, userToken, apiUrl) =>
+  apiPatch(apiUrl + '/api/users/me', updates, { token: userToken })
 
 export default {
   fetchUser,

--- a/front/src/store/stats.ts
+++ b/front/src/store/stats.ts
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import { apiGet } from '@/services/http'
 
 export default {
   state: {
@@ -40,32 +40,34 @@ export default {
 
   actions: {
     fetchSumByUserByMonth ({ state, commit, rootState }) {
-      axios.get(window.env.VITE_API_URL + '/api/operations/sumByUserByMonth', {
-        headers: {
-          Authorization: 'Bearer ' + rootState.user.token
-        },
-        params: {
-          monthNumber: state.currentMonth,
-          yearNumber: state.currentYear
+      apiGet<Array<{ MonthNegative: number }>>(
+        window.env.VITE_API_URL + '/api/operations/sumByUserByMonth',
+        {
+          token: rootState.user.token,
+          params: {
+            monthNumber: state.currentMonth,
+            yearNumber: state.currentYear
+          }
         }
-      }).then((response) => {
-        commit('setNegativeMonth', response.data[0].MonthNegative)
+      ).then((data) => {
+        commit('setNegativeMonth', data[0].MonthNegative)
       })
     },
 
     fetchSumCategoriesByUserByMonth ({ dispatch, commit, state, rootState }) {
       dispatch('fetchCategoryList')
 
-      axios.get(window.env.VITE_API_URL + '/api/operations/sumCategoriesByUserByMonth', {
-        headers: {
-          Authorization: 'Bearer ' + rootState.user.token
-        },
-        params: {
-          monthNumber: state.currentMonth,
-          yearNumber: state.currentYear
+      apiGet(
+        window.env.VITE_API_URL + '/api/operations/sumCategoriesByUserByMonth',
+        {
+          token: rootState.user.token,
+          params: {
+            monthNumber: state.currentMonth,
+            yearNumber: state.currentYear
+          }
         }
-      }).then((response) => {
-        commit('setCategoriesForMonth', response.data)
+      ).then((data) => {
+        commit('setCategoriesForMonth', data)
       })
     },
 

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -61,7 +61,7 @@ export default defineConfig({
             },
             {
               name: "vendor",
-              test: /[\\/]node_modules[\\/](axios|highcharts)[\\/]/,
+              test: /[\\/]node_modules[\\/]highcharts[\\/]/,
             },
           ],
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,9 +118,6 @@ importers:
       '@fortawesome/vue-fontawesome':
         specifier: ^3.1.3
         version: 3.1.3(@fortawesome/fontawesome-svg-core@6.7.2)(vue@3.5.32(typescript@5.9.3))
-      axios:
-        specifier: ^1.13.0
-        version: 1.15.0
       core-js:
         specifier: ^3.41.0
         version: 3.49.0
@@ -2038,9 +2035,6 @@ packages:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
-
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -3025,15 +3019,6 @@ packages:
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
-
-  follow-redirects@1.16.0:
-    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -4668,10 +4653,6 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
-
-  proxy-from-env@2.1.0:
-    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
-    engines: {node: '>=10'}
 
   pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
@@ -8194,14 +8175,6 @@ snapshots:
 
   aws-ssl-profiles@1.1.2: {}
 
-  axios@1.15.0:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.5
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-
   babel-jest@29.7.0(@babel/core@7.29.0):
     dependencies:
       '@babel/core': 7.29.0
@@ -9388,8 +9361,6 @@ snapshots:
   flat@5.0.2: {}
 
   flatted@3.4.2: {}
-
-  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:
@@ -11280,8 +11251,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  proxy-from-env@2.1.0: {}
 
   pseudomap@1.0.2: {}
 


### PR DESCRIPTION
Drop the axios runtime dependency in favour of a small fetch-based
helper (services/http.ts) and refactor every service + the stats
Vuex module to use it. Also drop axios from the Vite vendor chunk.